### PR TITLE
Always use OpenAI parser

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -15,9 +15,6 @@ COMPANY_ADDRESS=10 Jalan Perusahaan Amari, Batu Caves, Kuala Lumpur
 TAX_LABEL=SST
 TAX_PERCENT=0
 
-# Feature flags
-FEATURE_PARSE_REAL=1
-
 # Worker tuning
 WORKER_BATCH_SIZE=10
 WORKER_POLL_SECS=1.0

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,7 +1,7 @@
 # Backend (FastAPI + Postgres) — OrderOps Full Stack
 
 - Queue-driven parsing using Postgres `FOR UPDATE SKIP LOCKED`
-- OpenAI structured parsing (flip off by setting `FEATURE_PARSE_REAL=0` to dry-run)
+- OpenAI structured parsing with heuristic fallback when the OpenAI API is unavailable
 - Orders, Items, Plans (RENTAL/INSTALLMENT), Payments (POSTED/VOIDED)
 - Documents: invoice, receipt, installment agreement (simple PDFs)
 - Export: cash-basis payments to Excel

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -15,9 +15,6 @@ class Settings(BaseSettings):
     TAX_LABEL: str = "SST"
     TAX_PERCENT: float = 0.0
 
-    # Features
-    FEATURE_PARSE_REAL: bool = True
-
     # Worker
     WORKER_BATCH_SIZE: int = 10
     WORKER_POLL_SECS: float = 1.0

--- a/backend/app/services/parser.py
+++ b/backend/app/services/parser.py
@@ -155,7 +155,7 @@ def _heuristic_fallback(text: str) -> Dict[str, Any]:
     return data
 
 def parse_whatsapp_text(text: str) -> Dict[str, Any]:
-    if settings.FEATURE_PARSE_REAL and settings.OPENAI_API_KEY:
+    if settings.OPENAI_API_KEY:
         client = _openai_client()
         try:
             resp = client.chat.completions.create(

--- a/backend/tests/test_parser_delivery_fee.py
+++ b/backend/tests/test_parser_delivery_fee.py
@@ -38,7 +38,6 @@ class DummyClient:
         self.chat = DummyClient.Chat()
 
 def test_parse_item_and_delivery_fee(monkeypatch):
-    monkeypatch.setattr(settings, "FEATURE_PARSE_REAL", True)
     monkeypatch.setattr(settings, "OPENAI_API_KEY", "test")
     monkeypatch.setattr("app.services.parser._openai_client", lambda: DummyClient())
 

--- a/backend/tests/test_parser_mixed.py
+++ b/backend/tests/test_parser_mixed.py
@@ -40,7 +40,6 @@ class DummyClient:
         self.chat = DummyClient.Chat()
 
 def test_parse_mixed_items(monkeypatch):
-    monkeypatch.setattr(settings, "FEATURE_PARSE_REAL", True)
     monkeypatch.setattr(settings, "OPENAI_API_KEY", "test")
     monkeypatch.setattr("app.services.parser._openai_client", lambda: DummyClient())
 

--- a/render.yaml
+++ b/render.yaml
@@ -19,8 +19,6 @@ services:
         value: https://orderops-frontend-v1.vercel.app,http://localhost:3000
       - key: APP_VERSION
         value: "v1-fullstack"
-      - key: FEATURE_PARSE_REAL
-        value: "1"
       - key: WORKER_BATCH_SIZE
         value: "10"
       - key: WORKER_POLL_SECS
@@ -56,8 +54,6 @@ services:
         sync: false
       - key: APP_VERSION
         value: "v1-worker"
-      - key: FEATURE_PARSE_REAL
-        value: "1"
       - key: WORKER_BATCH_SIZE
         value: "10"
       - key: WORKER_POLL_SECS


### PR DESCRIPTION
## Summary
- remove `FEATURE_PARSE_REAL` flag from config, environments, and documentation
- run OpenAI parser whenever `OPENAI_API_KEY` is set, fallback to heuristic on failure
- adjust tests to patch only the OpenAI client

## Testing
- `cd backend && pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a5d0c5d030832eb3782bf2e35f1ac5