### PR TITLE
Remove temperature parameter from parser OpenAI call

### DIFF
--- a/backend/app/services/parser.py
+++ b/backend/app/services/parser.py
@@ -201,7 +201,6 @@ def parse_whatsapp_text(text: str) -> Dict[str, Any]:
         try:
             resp = client.chat.completions.create(
                 model="gpt-4o-mini",
-                temperature=0.1,
                 response_format={
                     "type": "json_schema",
                     "json_schema": {"name": "order", "schema": SCHEMA, "strict": True},


### PR DESCRIPTION
## Summary
- remove explicit temperature argument from `client.chat.completions.create` in WhatsApp text parser

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a5e12995b4832e82272ec7da494967