### PR TITLE
feat: add order return and buyback routes

### DIFF
--- a/frontend/pages/orders/[id].tsx
+++ b/frontend/pages/orders/[id].tsx
@@ -86,14 +86,21 @@ export default function OrderDetailPage(){
 
   async function onReturned(){
     setBusy(true); setErr(""); setMsg("");
-    try{ await markReturned(order.id); setMsg("Marked as returned"); await load(); }
-    catch(e:any){ setError(e); } finally{ setBusy(false); }
+    try{
+      const out = await markReturned(order.id);
+      setOrder(out?.order || out);
+      setMsg("Marked as returned");
+    }catch(e:any){ setError(e); } finally{ setBusy(false); }
   }
 
   async function onBuyback(){
     setBusy(true); setErr(""); setMsg("");
-    try{ await markBuyback(order.id, Number(buybackAmt||0)); setMsg("Buyback recorded"); await load(); }
-    catch(e:any){ setError(e); } finally{ setBusy(false); }
+    try{
+      const out = await markBuyback(order.id, Number(buybackAmt||0));
+      setOrder(out?.order || out);
+      setBuybackAmt("");
+      setMsg("Buyback recorded");
+    }catch(e:any){ setError(e); } finally{ setBusy(false); }
   }
 
   return (

--- a/frontend/utils/api.ts
+++ b/frontend/utils/api.ts
@@ -161,7 +161,9 @@ export async function voidOrder(id: number, reason?: string) {
 }
 
 export function markReturned(id: number, date?: string) {
-  return request<any>(`/orders/${id}/return`, { json: { date } });
+  const body: any = {};
+  if (date) body.date = date;
+  return request<any>(`/orders/${id}/return`, { json: body });
 }
 
 export function markBuyback(id: number, amount: number) {


### PR DESCRIPTION
## Summary
- add return and buyback endpoints for orders with balance recompute
- wire up API helpers and UI to show updated order status

## Testing
- `pytest`
- `npm --prefix frontend test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_b_68a5e8bc1074832ea590cffefddeea84