### PR TITLE
Add manual order creation UI and enhance order editing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+frontend/node_modules/
+__pycache__/
+*.pyc
+.env

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,5 +1,6 @@
 from pydantic import BaseModel, Field
 from typing import Optional, List
+from datetime import date
 
 class CustomerIn(BaseModel):
     name: str
@@ -50,15 +51,74 @@ class ParsedOrder(BaseModel):
 class OrderCreateIn(BaseModel):
     parsed: ParsedOrder
 
+class CustomerOut(BaseModel):
+    id: int
+    name: Optional[str] = None
+    phone: Optional[str] = None
+    address: Optional[str] = None
+    map_url: Optional[str] = None
+
+    class Config:
+        from_attributes = True
+
+
+class OrderItemOut(BaseModel):
+    id: int
+    name: str
+    sku: Optional[str] = None
+    category: Optional[str] = None
+    item_type: str
+    qty: float
+    unit_price: float
+    line_total: float
+
+    class Config:
+        from_attributes = True
+
+
+class PaymentOut(BaseModel):
+    id: int
+    amount: float
+    date: Optional[str] = None
+    method: Optional[str] = None
+    reference: Optional[str] = None
+    status: Optional[str] = None
+
+    class Config:
+        from_attributes = True
+
+
+class PlanOut(BaseModel):
+    id: int
+    plan_type: str
+    start_date: Optional[date] = None
+    months: Optional[int] = None
+    monthly_amount: float = 0
+    status: str
+
+    class Config:
+        from_attributes = True
+
+
 class OrderOut(BaseModel):
     id: int
     code: str
     type: str
     status: str
+    delivery_date: Optional[date] = None
+    notes: Optional[str] = None
     subtotal: float
+    discount: float | None = 0
+    delivery_fee: float | None = 0
+    return_delivery_fee: float | None = 0
+    penalty_fee: float | None = 0
     total: float
     paid_amount: float
     balance: float
+    customer: Optional[CustomerOut] = None
+    items: List[OrderItemOut] = Field(default_factory=list)
+    payments: List[PaymentOut] = Field(default_factory=list)
+    plan: Optional[PlanOut] = None
 
     class Config:
         from_attributes = True

--- a/frontend/components/Layout.tsx
+++ b/frontend/components/Layout.tsx
@@ -9,6 +9,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
         <nav className="nav">
           <Link href="/">Dashboard</Link>
           <Link href="/parse">Parse & Create</Link>
+          <Link href="/orders/new">New Order</Link>
           <Link href="/orders">Orders</Link>
           <Link href="/reports/outstanding">Outstanding</Link>
         </nav>

--- a/frontend/pages/orders/[id].tsx
+++ b/frontend/pages/orders/[id].tsx
@@ -24,6 +24,10 @@ export default function OrderDetailPage(){
   const [notes,setNotes] = React.useState<string>("");
   const [deliveryDate,setDeliveryDate] = React.useState<string>("");
 
+  const [planType,setPlanType] = React.useState<string>("");
+  const [planMonths,setPlanMonths] = React.useState<string>("");
+  const [planMonthly,setPlanMonthly] = React.useState<string>("");
+
   const [buybackAmt,setBuybackAmt] = React.useState<string>("");
 
   const [due,setDue] = React.useState<any>(null);
@@ -42,6 +46,9 @@ export default function OrderDetailPage(){
       setRetDelFee(String(o?.return_delivery_fee ?? ""));
       setNotes(String(o?.notes ?? ""));
       setDeliveryDate(o?.delivery_date ? (o.delivery_date as string).slice(0,10) : "");
+      setPlanType(String(o?.plan?.plan_type ?? ""));
+      setPlanMonths(o?.plan?.months ? String(o.plan.months) : "");
+      setPlanMonthly(o?.plan?.monthly_amount ? String(o.plan.monthly_amount) : "");
       await loadDue(o.id, asOf);
     }catch(e:any){ setError(e); }
   }
@@ -70,6 +77,13 @@ export default function OrderDetailPage(){
         notes,
       };
       if(deliveryDate) patch.delivery_date = deliveryDate; // ISO
+      if(planType || planMonths || planMonthly){
+        patch.plan = {
+          plan_type: planType || undefined,
+          months: planMonths ? Number(planMonths) : undefined,
+          monthly_amount: planMonthly ? Number(planMonthly) : undefined,
+        };
+      }
       const out = await updateOrder(order.id, patch);
       setMsg("Order updated"); setOrder(out);
     }catch(e:any){ setError(e); } finally{ setBusy(false); }
@@ -198,6 +212,18 @@ export default function OrderDetailPage(){
             <div className="row">
               <div className="col"><label>Delivery Fee</label><input className="input" value={delFee} onChange={e=>setDelFee(e.target.value)} /></div>
               <div className="col"><label>Return Delivery Fee</label><input className="input" value={retDelFee} onChange={e=>setRetDelFee(e.target.value)} /></div>
+            </div>
+            <div className="row">
+              <div className="col">
+                <label>Plan Type</label>
+                <select className="select" value={planType} onChange={e=>setPlanType(e.target.value)}>
+                  <option value="">None</option>
+                  <option>INSTALLMENT</option>
+                  <option>RENTAL</option>
+                </select>
+              </div>
+              <div className="col"><label>Months</label><input className="input" value={planMonths} onChange={e=>setPlanMonths(e.target.value)} /></div>
+              <div className="col"><label>Monthly Amount</label><input className="input" value={planMonthly} onChange={e=>setPlanMonthly(e.target.value)} /></div>
             </div>
             <div style={{marginTop:8}}>
               <label>Notes</label>

--- a/frontend/pages/orders/index.tsx
+++ b/frontend/pages/orders/index.tsx
@@ -41,6 +41,7 @@ export default function OrdersPage(){
           </div>
           <div className="col" style={{display:"flex",alignItems:"center",gap:8}}>
             <button className="btn" onClick={load} disabled={loading}>{loading?"Loading...":"Search"}</button>
+            <Link className="btn secondary" href="/orders/new">Create Manually</Link>
             <Link className="btn secondary" href="/parse">Create from Parse</Link>
           </div>
         </div>

--- a/frontend/pages/orders/new.tsx
+++ b/frontend/pages/orders/new.tsx
@@ -1,0 +1,114 @@
+import Layout from "@/components/Layout";
+import React from "react";
+import { useRouter } from "next/router";
+import { createManualOrder } from "@/utils/api";
+
+export default function NewOrderPage(){
+  const router = useRouter();
+  const [custName,setCustName] = React.useState("");
+  const [custPhone,setCustPhone] = React.useState("");
+  const [custAddress,setCustAddress] = React.useState("");
+
+  const [type,setType] = React.useState("OUTRIGHT");
+  const [deliveryDate,setDeliveryDate] = React.useState("");
+  const [notes,setNotes] = React.useState("");
+
+  const [items,setItems] = React.useState<any[]>([{ name:"", item_type:"OUTRIGHT", qty:1, unit_price:"", monthly_amount:"" }]);
+
+  const [busy,setBusy] = React.useState(false);
+  const [err,setErr] = React.useState("");
+
+  function updateItem(idx:number, field:string, value:any){
+    const copy = [...items];
+    copy[idx] = { ...copy[idx], [field]: value };
+    setItems(copy);
+  }
+
+  function addItem(){
+    setItems([...items, { name:"", item_type:"OUTRIGHT", qty:1, unit_price:"", monthly_amount:"" }]);
+  }
+
+  function removeItem(idx:number){
+    setItems(items.filter((_,i)=>i!==idx));
+  }
+
+  async function onCreate(){
+    setBusy(true); setErr("");
+    try{
+      const payload = {
+        customer: { name: custName, phone: custPhone || undefined, address: custAddress || undefined },
+        order: {
+          type,
+          delivery_date: deliveryDate || undefined,
+          notes: notes || undefined,
+          items: items.map(it=>({
+            name: it.name,
+            item_type: it.item_type,
+            qty: Number(it.qty||0),
+            unit_price: Number(it.unit_price||0),
+            line_total: Number(it.unit_price||0) * Number(it.qty||0),
+            ...(it.monthly_amount ? { monthly_amount: Number(it.monthly_amount||0) } : {})
+          }))
+        }
+      };
+      const out = await createManualOrder(payload);
+      const oid = out?.id || out?.order_id;
+      if(oid) router.push(`/orders/${oid}`);
+    }catch(e:any){ setErr(e?.message || "Create failed"); }
+    finally{ setBusy(false); }
+  }
+
+  return (
+    <Layout>
+      <div className="card">
+        <h2 style={{marginTop:0}}>New Order</h2>
+        <div className="row">
+          <div className="col"><label>Customer Name</label><input className="input" value={custName} onChange={e=>setCustName(e.target.value)} /></div>
+          <div className="col"><label>Phone</label><input className="input" value={custPhone} onChange={e=>setCustPhone(e.target.value)} /></div>
+        </div>
+        <div style={{marginTop:8}}><label>Address</label><textarea className="textarea" rows={2} value={custAddress} onChange={e=>setCustAddress(e.target.value)} /></div>
+        <div className="row">
+          <div className="col"><label>Type</label>
+            <select className="select" value={type} onChange={e=>setType(e.target.value)}>
+              <option>OUTRIGHT</option>
+              <option>INSTALLMENT</option>
+              <option>RENTAL</option>
+              <option>MIXED</option>
+            </select>
+          </div>
+          <div className="col"><label>Delivery Date</label><input className="input" type="date" value={deliveryDate} onChange={e=>setDeliveryDate(e.target.value)} /></div>
+        </div>
+        <div style={{marginTop:8}}><label>Notes</label><textarea className="textarea" rows={2} value={notes} onChange={e=>setNotes(e.target.value)} /></div>
+
+        <div className="hr" />
+        <h3>Items</h3>
+        <table className="table">
+          <thead><tr><th>Name</th><th>Type</th><th>Qty</th><th>Unit Price</th><th>Monthly</th><th></th></tr></thead>
+          <tbody>
+            {items.map((it,idx)=>(
+              <tr key={idx}>
+                <td><input className="input" value={it.name} onChange={e=>updateItem(idx,'name',e.target.value)} /></td>
+                <td>
+                  <select className="select" value={it.item_type} onChange={e=>updateItem(idx,'item_type',e.target.value)}>
+                    <option>OUTRIGHT</option>
+                    <option>INSTALLMENT</option>
+                    <option>RENTAL</option>
+                    <option>FEE</option>
+                  </select>
+                </td>
+                <td><input className="input" value={it.qty} onChange={e=>updateItem(idx,'qty',e.target.value)} /></td>
+                <td><input className="input" value={it.unit_price} onChange={e=>updateItem(idx,'unit_price',e.target.value)} /></td>
+                <td><input className="input" value={it.monthly_amount} onChange={e=>updateItem(idx,'monthly_amount',e.target.value)} /></td>
+                <td><button className="btn secondary" onClick={()=>removeItem(idx)}>Remove</button></td>
+              </tr>
+            ))}
+            <tr><td colSpan={6}><button className="btn secondary" onClick={addItem}>Add Item</button></td></tr>
+          </tbody>
+        </table>
+
+        {err && <div style={{marginTop:8,color:'#ffb3b3'}}>{err}</div>}
+        <div style={{marginTop:8}}><button className="btn" onClick={onCreate} disabled={busy || !custName || items.length===0}>Create Order</button></div>
+      </div>
+    </Layout>
+  );
+}

--- a/frontend/utils/api.ts
+++ b/frontend/utils/api.ts
@@ -136,6 +136,10 @@ export async function createOrderFromParsed(parsed: any) {
   }
 }
 
+export function createManualOrder(payload: { customer: any; order: any }) {
+  return request<any>("/orders", { json: payload });
+}
+
 export function updateOrder(id: number, patch: any) {
   return request<any>(`/orders/${id}`, { method: "PATCH", json: patch }).catch((e: any) => {
     if (e?.status === 405) return request<any>(`/orders/${id}`, { method: "PUT", json: patch });


### PR DESCRIPTION
## Summary
- allow filtering orders by query, status, and type
- support updating order plans/items and return full details
- add manual order creation page and navigation

## Testing
- `pytest -q`
- `npm test` (fails: missing script)
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_68a5f5b35a24832e877a5034234d60a1