### PR TITLE
Fix schema merge conflict and typing in payment model

### DIFF
--- a/backend/app/models/payment.py
+++ b/backend/app/models/payment.py
@@ -1,3 +1,5 @@
+from datetime import date, datetime
+
 from sqlalchemy import BigInteger, Date, String, Numeric, ForeignKey, DateTime, func, Text
 from sqlalchemy.orm import Mapped, mapped_column
 from .base import Base
@@ -6,12 +8,12 @@ class Payment(Base):
     __tablename__ = "payments"
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
     order_id: Mapped[int] = mapped_column(ForeignKey("orders.id"), nullable=False, index=True)
-    date: Mapped[str] = mapped_column(Date, nullable=False)
+    date: Mapped[date] = mapped_column(Date, nullable=False)
     amount: Mapped[float] = mapped_column(Numeric(12,2), nullable=False)
     method: Mapped[str | None] = mapped_column(String(30), nullable=True)  # cash/transfer/cheque/etc
     reference: Mapped[str | None] = mapped_column(String(100), nullable=True)
     category: Mapped[str] = mapped_column(String(20), default="ORDER")  # ORDER|RENTAL|INSTALLMENT|PENALTY|DELIVERY|BUYBACK
     status: Mapped[str] = mapped_column(String(20), default="POSTED")  # POSTED|VOIDED
     void_reason: Mapped[str | None] = mapped_column(Text, nullable=True)
-    created_at: Mapped[str] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
-    updated_at: Mapped[str] = mapped_column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -79,13 +79,7 @@ class OrderItemOut(BaseModel):
 class PaymentOut(BaseModel):
     id: int
     amount: float
-
-
     date: Optional[date] = None
-
-    date: Optional[str] = None
-
-      >>>>>>> main
     method: Optional[str] = None
     reference: Optional[str] = None
     status: Optional[str] = None


### PR DESCRIPTION
## Summary
- remove merge conflict artifacts from `PaymentOut` schema
- correct SQLAlchemy `Payment` model types for date and timestamps

## Testing
- `pytest`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68a66b9fc820832e9b5192e0e11a4da6