### PR TITLE
Fix PaymentOut date field causing order retrieval failure

### DIFF
--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,6 +1,6 @@
 from pydantic import BaseModel, Field
 from typing import Optional, List
-from datetime import date
+import datetime as dt
 
 class CustomerIn(BaseModel):
     name: str
@@ -79,7 +79,7 @@ class OrderItemOut(BaseModel):
 class PaymentOut(BaseModel):
     id: int
     amount: float
-    date: Optional[date] = None
+    date: Optional[dt.date] = None
     method: Optional[str] = None
     reference: Optional[str] = None
     status: Optional[str] = None
@@ -91,7 +91,7 @@ class PaymentOut(BaseModel):
 class PlanOut(BaseModel):
     id: int
     plan_type: str
-    start_date: Optional[date] = None
+    start_date: Optional[dt.date] = None
     months: Optional[int] = None
     monthly_amount: float = 0
     status: str
@@ -105,7 +105,7 @@ class OrderOut(BaseModel):
     code: str
     type: str
     status: str
-    delivery_date: Optional[date] = None
+    delivery_date: Optional[dt.date] = None
     notes: Optional[str] = None
     subtotal: float
     discount: float | None = 0


### PR DESCRIPTION
## Summary
- Avoid shadowing `datetime.date` in PaymentOut by importing `datetime` as `dt`
- Apply `dt.date` annotations to payment, plan and order output models

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a66fbb78d8832e9187c3d0df950308