### PR TITLE
Fix delivery fee parsing for FOC cases

### DIFF
--- a/backend/tests/test_parser_delivery_fee.py
+++ b/backend/tests/test_parser_delivery_fee.py
@@ -49,3 +49,15 @@ def test_parse_item_and_delivery_fee(monkeypatch):
     assert norm["order"]["items"][0]["name"].lower() == "tilam canvas"
     assert float(norm["order"]["items"][0]["line_total"]) == 199
     assert float(norm["order"]["charges"]["delivery_fee"]) == 20
+
+
+def test_parse_delivery_fee_foc(monkeypatch):
+    monkeypatch.setattr(settings, "OPENAI_API_KEY", "test")
+    monkeypatch.setattr("app.services.parser._openai_client", lambda: DummyClient())
+
+    text = "Auto travel steel wheelchair RM2200\nDelivery FOC"
+    data = parse_whatsapp_text(text)
+    norm = _post_normalize(data, text)
+
+    assert float(norm["order"]["charges"].get("delivery_fee", 0)) == 0
+    assert float(norm["order"]["totals"]["total"]) == 2200


### PR DESCRIPTION
## Summary
- Improve delivery-fee extraction to detect explicit lines and FOC/free markers
- Always override LLM delivery-fee with heuristic result
- Add regression test for FOC delivery fee

## Testing
- `pytest tests/test_parser_delivery_fee.py -q`

------
https://chatgpt.com/codex/tasks/task_b_68a671d8a5d4832e95275b70673512c7