### PR TITLE
feat: add payments received export

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -4,7 +4,7 @@
 - OpenAI structured parsing with heuristic fallback when the OpenAI API is unavailable
 - Orders, Items, Plans (RENTAL/INSTALLMENT), Payments (POSTED/VOIDED)
 - Documents: invoice, receipt, installment agreement (simple PDFs)
-- Export: cash-basis payments to Excel
+- Export: cash-basis payments to Excel (``/export/cash.xlsx`` or ``/export/payments_received.xlsx``)
 
 ## Local dev (Windows)
 ```powershell

--- a/backend/app/routers/export.py
+++ b/backend/app/routers/export.py
@@ -39,3 +39,14 @@ def cash_export(start: str, end: str, db: Session = Depends(get_session)):
 
     headers = {"Content-Disposition": f'attachment; filename="cash_{start}_{end}.xlsx"'}
     return Response(content=bio.getvalue(), media_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", headers=headers)
+
+
+@router.get("/payments_received.xlsx")
+def payments_received_export(start: str, end: str, db: Session = Depends(get_session)):
+    """Export posted payments by received date in Excel format.
+
+    This is an alias for :func:`cash_export` but exposes a more descriptive
+    endpoint name for consumers looking specifically for payment receipts on a
+    cash basis.
+    """
+    return cash_export(start, end, db)


### PR DESCRIPTION
## Summary
- add `/export/payments_received.xlsx` endpoint to expose cash-basis payment export
- document export endpoint

## Testing
- `cd backend && pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a82b3b199c832e9b39f6d16fc62546