### PR TITLE
refactor: replace utcnow usage

### DIFF
--- a/backend/app/utils/dates.py
+++ b/backend/app/utils/dates.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 import re
 from typing import Optional
 
@@ -30,7 +30,7 @@ def parse_relaxed_date(text: str) -> Optional[date]:
         month = int(m.group(2))
         year_part = m.group(3)
         if year_part is None:
-            year = datetime.utcnow().year
+            year = datetime.now(timezone.utc).year
         else:
             year = int(year_part)
             if year < 100:


### PR DESCRIPTION
## Summary
- use timezone-aware datetime instead of deprecated `utcnow`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a82f7f0228832e9e5be3082967ec24