### PR TITLE
Handle missing ReportLab gracefully and add PDF generation tests

### DIFF
--- a/backend/app/services/documents.py
+++ b/backend/app/services/documents.py
@@ -1,9 +1,26 @@
-from reportlab.pdfgen import canvas
+"""PDF generation utilities using ReportLab.
+
+This module generates various PDF documents related to orders. ReportLab is an
+optional dependency, so we provide a clear error message if it's missing at
+runtime.
+"""
+
+try:  # pragma: no cover - exercised indirectly in tests
+    from reportlab.pdfgen import canvas
+except ImportError as exc:  # pragma: no cover - tested by import
+    raise ImportError(
+        "ReportLab is required to generate PDF documents. Install it with 'pip install reportlab'."
+    ) from exc
+
 from reportlab.lib.pagesizes import A4
 from reportlab.lib.units import mm
 from textwrap import wrap
 from io import BytesIO
+
 from ..core.config import settings
+from ..models.order import Order
+from ..models.payment import Payment
+from ..models.plan import Plan
 
 def _draw_lines(c, x, y, lines, max_width_mm=180, leading=14):
     width = max_width_mm * mm
@@ -15,7 +32,7 @@ def _draw_lines(c, x, y, lines, max_width_mm=180, leading=14):
             y -= leading/3.0
     return y
 
-def invoice_pdf(order) -> bytes:
+def invoice_pdf(order: Order) -> bytes:
     buf = BytesIO()
     c = canvas.Canvas(buf, pagesize=A4)
     x, y = 20, 280
@@ -60,7 +77,7 @@ def invoice_pdf(order) -> bytes:
     pdf = buf.getvalue(); buf.close()
     return pdf
 
-def receipt_pdf(order, payment) -> bytes:
+def receipt_pdf(order: Order, payment: Payment) -> bytes:
     buf = BytesIO(); c = canvas.Canvas(buf, pagesize=A4)
     x, y = 20, 280
     c.setFont("Helvetica-Bold", 14)
@@ -82,7 +99,7 @@ def receipt_pdf(order, payment) -> bytes:
     pdf = buf.getvalue(); buf.close()
     return pdf
 
-def installment_agreement_pdf(order, plan) -> bytes:
+def installment_agreement_pdf(order: Order, plan: Plan) -> bytes:
     buf = BytesIO(); c = canvas.Canvas(buf, pagesize=A4)
     x, y = 20, 280
     c.setFont("Helvetica-Bold", 14)

--- a/backend/tests/test_documents.py
+++ b/backend/tests/test_documents.py
@@ -1,0 +1,64 @@
+import sys
+from pathlib import Path
+from datetime import date
+from types import SimpleNamespace
+
+# Ensure backend package is importable
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app.services.documents import invoice_pdf, receipt_pdf, installment_agreement_pdf  # noqa: E402
+
+
+def _sample_order():
+    customer = SimpleNamespace(name="John Doe", phone="123", address="123 Street")
+    item = SimpleNamespace(name="Widget", qty=1, unit_price=10.0, line_total=10.0)
+    return SimpleNamespace(
+        code="ORD001",
+        customer=customer,
+        items=[item],
+        subtotal=10.0,
+        discount=0.0,
+        delivery_fee=0.0,
+        return_delivery_fee=0.0,
+        penalty_fee=0.0,
+        total=10.0,
+        paid_amount=0.0,
+        balance=10.0,
+    )
+
+
+def _sample_payment():
+    return SimpleNamespace(
+        date=date.today(),
+        amount=10.0,
+        method="cash",
+        reference="ref",
+        status="POSTED",
+    )
+
+
+def _sample_plan():
+    return SimpleNamespace(months=6, monthly_amount=1.0)
+
+
+def test_invoice_pdf_generates_bytes():
+    order = _sample_order()
+    pdf = invoice_pdf(order)
+    assert isinstance(pdf, (bytes, bytearray))
+    assert len(pdf) > 0
+
+
+def test_receipt_pdf_generates_bytes():
+    order = _sample_order()
+    payment = _sample_payment()
+    pdf = receipt_pdf(order, payment)
+    assert isinstance(pdf, (bytes, bytearray))
+    assert len(pdf) > 0
+
+
+def test_installment_agreement_pdf_generates_bytes():
+    order = _sample_order()
+    plan = _sample_plan()
+    pdf = installment_agreement_pdf(order, plan)
+    assert isinstance(pdf, (bytes, bytearray))
+    assert len(pdf) > 0


### PR DESCRIPTION
## Summary
- Add explicit ReportLab import with helpful error message
- Annotate PDF generation functions with concrete model types
- Test invoice, receipt and installment agreement PDF generation

## Testing
- `cd backend && pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68a83bbfcf88832e86484a6e86757859