### PR TITLE
refactor: centralize normalization utils

### DIFF
--- a/backend/app/routers/payments.py
+++ b/backend/app/routers/payments.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from decimal import Decimal
 from datetime import date
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
@@ -8,16 +7,9 @@ from sqlalchemy.orm import Session
 
 from ..db import get_session
 from ..models import Payment, Order
+from ..utils.normalize import to_decimal
 
 router = APIRouter(prefix="/payments", tags=["payments"])
-
-def _d(x) -> Decimal:
-    if isinstance(x, Decimal):
-        return x
-    try:
-        return Decimal(str(x or 0)).quantize(Decimal("0.01"))
-    except Exception:
-        return Decimal("0.00")
 
 class PaymentIn(BaseModel):
     order_id: int
@@ -33,11 +25,11 @@ def add_payment(body: PaymentIn, db: Session = Depends(get_session)):
     if not order:
         raise HTTPException(404, "Order not found")
     pdate = date.fromisoformat(body.date) if body.date else date.today()
-    amount = _d(body.amount)
+    amount = to_decimal(body.amount)
     p = Payment(order_id=order.id, amount=amount, date=pdate, method=body.method, reference=body.reference, category=body.category or "ORDER")
     db.add(p)
-    order.paid_amount = _d(order.paid_amount) + amount
-    order.balance = _d(order.total) - _d(order.paid_amount)
+    order.paid_amount = to_decimal(order.paid_amount) + amount
+    order.balance = to_decimal(order.total) - to_decimal(order.paid_amount)
     db.commit()
     db.refresh(order)
     return {"payment_id": p.id, "order_balance": float(order.balance)}
@@ -55,8 +47,8 @@ def void_payment(payment_id: int, body: VoidIn, db: Session = Depends(get_sessio
     p.status = "VOIDED"
     p.void_reason = body.reason or ""
     order = db.get(Order, p.order_id)
-    order.paid_amount = _d(order.paid_amount) - _d(p.amount)
-    order.balance = _d(order.total) - _d(order.paid_amount)
+    order.paid_amount = to_decimal(order.paid_amount) - to_decimal(p.amount)
+    order.balance = to_decimal(order.total) - to_decimal(order.paid_amount)
     db.commit()
     db.refresh(order)
     return {"ok": True, "status": "VOIDED", "order_balance": float(order.balance)}

--- a/backend/app/utils/normalize.py
+++ b/backend/app/utils/normalize.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from decimal import Decimal, ROUND_HALF_UP, InvalidOperation
+from typing import Any, Dict, List
+
+DECIMAL_ZERO = Decimal("0.00")
+
+
+def to_decimal(value: Any, default: Decimal = DECIMAL_ZERO) -> Decimal:
+    """Safely coerce ``value`` into a :class:`~decimal.Decimal` rounded to 2dp.
+
+    ``None`` or invalid inputs return ``default`` (0.00 by default).
+    """
+    if value is None:
+        return default
+    if isinstance(value, Decimal):
+        try:
+            return value.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+        except Exception:
+            return default
+    try:
+        return Decimal(str(value)).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+    except (InvalidOperation, ValueError, TypeError):
+        return default
+
+
+def ensure_dict(x: Any) -> Dict[str, Any]:
+    """Return ``x`` if it's a ``dict`` else an empty dict."""
+    return x if isinstance(x, dict) else {}
+
+
+def ensure_list(x: Any) -> List[Any]:
+    """Return ``x`` if it's a ``list`` else an empty list."""
+    return x if isinstance(x, list) else []

--- a/backend/tests/test_normalize.py
+++ b/backend/tests/test_normalize.py
@@ -1,0 +1,23 @@
+import sys
+from pathlib import Path
+from decimal import Decimal
+
+# Ensure backend package is importable
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app.utils.normalize import to_decimal, ensure_dict, ensure_list  # noqa: E402
+
+
+def test_to_decimal_handles_various_inputs():
+    assert to_decimal(None) == Decimal("0.00")
+    assert to_decimal("3.456") == Decimal("3.46")
+    assert to_decimal("not a number") == Decimal("0.00")
+    assert to_decimal(Decimal("1.235")) == Decimal("1.24")
+
+
+def test_ensure_dict_and_list_defaults():
+    assert ensure_dict(None) == {}
+    assert ensure_dict({"a": 1}) == {"a": 1}
+    assert ensure_list(None) == []
+    assert ensure_list("foo") == []
+    assert ensure_list([1, 2]) == [1, 2]


### PR DESCRIPTION
## Summary
- introduce shared normalization helpers for decimals, dicts, and lists
- refactor order parsing, order service, and payments to leverage new helpers
- add unit tests covering edge cases for normalization utilities

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a83ba9db34832eb03e06a0c2c781cf