### PR TITLE
Add CI workflow for backend and frontend checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,76 @@
+name: CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+
+jobs:
+  backend:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('backend/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install black flake8 mypy pytest pytest-cov
+
+      - name: Lint
+        run: |
+          black --check .
+          flake8 .
+          mypy .
+
+      - name: Test
+        run: pytest --cov=app --cov-report=xml
+
+      - name: Upload coverage
+        uses: actions/upload-artifact@v4
+        with:
+          name: backend-coverage
+          path: backend/coverage.xml
+
+  frontend:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Type check
+        run: npx tsc --noEmit
+
+      - name: Build
+        run: npm run build

--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# OrderOps Full Stack
+
+This repository contains a FastAPI backend and a Next.js frontend. The CI workflow checks code style, types, tests and build for both parts.
+
+## Running checks locally
+
+### Backend
+
+```bash
+cd backend
+pip install -r requirements.txt
+pip install black flake8 mypy pytest pytest-cov
+black --check .
+flake8 .
+mypy .
+pytest --cov=app
+```
+
+### Frontend
+
+```bash
+cd frontend
+npm ci
+npm run lint
+npx tsc --noEmit
+npm run build
+```


### PR DESCRIPTION
## Summary
- run backend checks with black, flake8, mypy and pytest w/ coverage
- run frontend npm install, lint, type-check and build
- document local commands in README

## Testing
- `black --check .` *(fails: would reformat 32 files)*
- `flake8 .` *(fails: multiple lint errors)*
- `mypy .` *(fails: missing stubs and type errors)*
- `pytest`
- `npm run lint`
- `npx tsc --noEmit`
- `npm run build` *(fails: unknown Tailwind utility `bg-brand-50`)*

------
https://chatgpt.com/codex/tasks/task_b_68a83bda5b5c832eb81226aa1671881c