### PR TITLE
feat: add typed API interfaces

### DIFF
--- a/frontend/components/OrderMini.tsx
+++ b/frontend/components/OrderMini.tsx
@@ -1,7 +1,8 @@
 import Link from "next/link";
 import StatusBadge from "./StatusBadge";
+import { Order } from "@/utils/api";
 
-export default function OrderMini({order}:{order:any}){
+export default function OrderMini({order}:{order:Order}){
   return (
     <tr>
       <td><Link href={`/orders/${order.id}`}>{order.code || order.id}</Link></td>

--- a/frontend/pages/orders/index.tsx
+++ b/frontend/pages/orders/index.tsx
@@ -1,13 +1,13 @@
 import Layout from "@/components/Layout";
 import Link from "next/link";
 import React from "react";
-import { listOrders } from "@/utils/api";
+import { listOrders, Order } from "@/utils/api";
 
 export default function OrdersPage(){
   const [q,setQ] = React.useState("");
   const [status,setStatus] = React.useState("");
   const [type,setType] = React.useState("");
-  const [items,setItems] = React.useState<any[]>([]);
+  const [items,setItems] = React.useState<Order[]>([]);
   const [loading,setLoading] = React.useState(false);
 
   async function load(){
@@ -50,7 +50,7 @@ export default function OrdersPage(){
           <table className="table">
             <thead><tr><th>Code</th><th>Type</th><th>Status</th><th>Total</th><th>Paid</th><th>Balance</th></tr></thead>
             <tbody>
-              {items.map((o:any)=>(
+              {items.map((o:Order)=>(
                 <tr key={o.id}>
                   <td><Link href={`/orders/${o.id}`}>{o.code||o.id}</Link></td>
                   <td>{o.type}</td>

--- a/frontend/pages/orders/new.tsx
+++ b/frontend/pages/orders/new.tsx
@@ -3,6 +3,14 @@ import React from "react";
 import { useRouter } from "next/router";
 import { createManualOrder } from "@/utils/api";
 
+interface ItemInput {
+  name: string;
+  item_type: string;
+  qty: number;
+  unit_price: string;
+  monthly_amount: string;
+}
+
 export default function NewOrderPage(){
   const router = useRouter();
   const [custName,setCustName] = React.useState("");
@@ -13,12 +21,12 @@ export default function NewOrderPage(){
   const [deliveryDate,setDeliveryDate] = React.useState("");
   const [notes,setNotes] = React.useState("");
 
-  const [items,setItems] = React.useState<any[]>([{ name:"", item_type:"OUTRIGHT", qty:1, unit_price:"", monthly_amount:"" }]);
+  const [items,setItems] = React.useState<ItemInput[]>([{ name:"", item_type:"OUTRIGHT", qty:1, unit_price:"", monthly_amount:"" }]);
 
   const [busy,setBusy] = React.useState(false);
   const [err,setErr] = React.useState("");
 
-  function updateItem(idx:number, field:string, value:any){
+  function updateItem(idx:number, field:string, value:unknown){
     const copy = [...items];
     copy[idx] = { ...copy[idx], [field]: value };
     setItems(copy);
@@ -54,7 +62,7 @@ export default function NewOrderPage(){
       const out = await createManualOrder(payload);
       const oid = out?.id || out?.order_id;
       if(oid) router.push(`/orders/${oid}`);
-    }catch(e:any){ setErr(e?.message || "Create failed"); }
+    }catch(e){ const err = e as { message?: string }; setErr(err?.message || "Create failed"); }
     finally{ setBusy(false); }
   }
 

--- a/frontend/pages/reports/outstanding.tsx
+++ b/frontend/pages/reports/outstanding.tsx
@@ -1,11 +1,11 @@
 import Layout from "@/components/Layout";
 import React from "react";
-import { outstanding } from "@/utils/api";
+import { outstanding, Order } from "@/utils/api";
 import Link from "next/link";
 
 export default function OutstandingPage(){
   const [tab,setTab] = React.useState<"INSTALLMENT"|"RENTAL">("INSTALLMENT");
-  const [rows,setRows] = React.useState<any[]>([]);
+  const [rows,setRows] = React.useState<Order[]>([]);
   const [loading,setLoading] = React.useState(false);
 
   async function load(){
@@ -32,7 +32,7 @@ export default function OutstandingPage(){
           <table className="table">
             <thead><tr><th>Code</th><th>Customer</th><th>Type</th><th>Status</th><th>Balance</th></tr></thead>
             <tbody>
-              {rows.map((r:any)=>(
+              {rows.map((r:Order)=>(
                 <tr key={r.id}>
                   <td><Link href={`/orders/${r.id}`}>{r.code||r.id}</Link></td>
                   <td>{r.customer?.name}</td>

--- a/frontend/utils/api.ts
+++ b/frontend/utils/api.ts
@@ -1,5 +1,78 @@
 // utils/api.ts
-export type Json = Record<string, any> | any[];
+export type Json = Record<string, unknown> | unknown[];
+
+export interface Customer {
+  name: string;
+  phone?: string;
+  address?: string;
+  [key: string]: unknown;
+}
+
+export interface Plan {
+  plan_type?: string;
+  months?: number;
+  monthly_amount?: number;
+  [key: string]: unknown;
+}
+
+export interface OrderItem {
+  id?: number;
+  name?: string;
+  item_type?: string;
+  qty?: number;
+  unit_price?: number;
+  monthly_amount?: number;
+  line_total?: number;
+  [key: string]: unknown;
+}
+
+export interface Order {
+  id: number;
+  code?: string;
+  type?: string;
+  status?: string;
+  subtotal?: number;
+  delivery_fee?: number;
+  return_delivery_fee?: number;
+  penalty_fee?: number;
+  discount?: number;
+  total?: number;
+  paid_amount?: number;
+  balance?: number;
+  delivery_date?: string;
+  notes?: string;
+  items?: OrderItem[];
+  customer?: Customer;
+  plan?: Plan;
+  payments?: Payment[];
+  [key: string]: unknown;
+}
+
+export interface OrdersList {
+  items: Order[];
+  total?: number;
+}
+
+export interface ParseResponse {
+  parsed?: unknown;
+  [key: string]: unknown;
+}
+
+export interface Due {
+  accrued?: number;
+  outstanding?: number;
+  [key: string]: unknown;
+}
+
+export interface Payment {
+  id: number;
+  date?: string;
+  amount?: number;
+  method?: string;
+  reference?: string;
+  status?: string;
+  [key: string]: unknown;
+}
 
 function normalizeBase(s?: string) {
   if (!s) return "";
@@ -14,13 +87,13 @@ function pathJoin(p: string) {
   return `${API_BASE}${p.startsWith("/") ? p : `/${p}`}`;
 }
 
-async function request<T = any>(
+async function request<T = unknown>(
   path: string,
-  init?: RequestInit & { json?: any }
+  init?: RequestInit & { json?: unknown }
 ): Promise<T> {
   const { json, headers, ...rest } = init || {};
   const res = await fetch(pathJoin(path), {
-    method: json ? "POST" : (rest.method || "GET"),
+    method: json ? "POST" : rest.method || "GET",
     headers: {
       Accept: "application/json",
       ...(json ? { "Content-Type": "application/json" } : {}),
@@ -28,20 +101,29 @@ async function request<T = any>(
     },
     body: json ? JSON.stringify(json) : rest.body,
     ...rest,
-  }).catch((e: any) => {
-    throw new Error(`Network error calling ${path}: ${e?.message || "failed to fetch"}`);
+  }).catch((e: unknown) => {
+    const err = e as { message?: string };
+    throw new Error(
+      `Network error calling ${path}: ${err?.message || "failed to fetch"}`
+    );
   });
 
   const text = await res.text();
   const isJSON = res.headers.get("content-type")?.includes("application/json");
-  const data: any = isJSON && text ? JSON.parse(text) : text;
+  const data: unknown = isJSON && text ? JSON.parse(text) : text;
 
   if (!res.ok) {
+    const parsed = data as Record<string, unknown> | string;
+    const parsedRecord = parsed as Record<string, unknown>;
     const msg =
-      (isJSON && (data?.detail || data?.message)) ||
-      (typeof data === "string" && data) ||
+      (typeof parsed === "object" && typeof parsedRecord["detail"] === "string" && parsedRecord["detail"] as string) ||
+      (typeof parsed === "object" && typeof parsedRecord["message"] === "string" && parsedRecord["message"] as string) ||
+      (typeof parsed === "string" && parsed) ||
       res.statusText;
-    const err: any = new Error(msg || `HTTP ${res.status}`);
+    const err = new Error(msg || `HTTP ${res.status}`) as Error & {
+      status?: number;
+      data?: unknown;
+    };
     err.status = res.status;
     err.data = data;
     throw err;
@@ -55,12 +137,11 @@ export function ping() {
 }
 
 // -------- Parse
-export function parseMessage(text: string) {
-  return request<Json>("/parse", { json: { text, message: text } });
+export function parseMessage(text: string): Promise<ParseResponse> {
+  return request<ParseResponse>("/parse", { json: { text, message: text } });
 }
 
 // -------- Orders (normalized)
-type OrdersList = { items: any[]; total?: number };
 
 export async function listOrders(
   q?: string,
@@ -73,90 +154,126 @@ export async function listOrders(
   if (type) sp.set("type", type);
   const qs = sp.toString();
 
-  const data = await request<any>(`/orders${qs ? `?${qs}` : ""}`);
+  const data = await request<unknown>(`/orders${qs ? `?${qs}` : ""}`);
   // Normalize: backend may return array or { items, total }
-  if (Array.isArray(data)) return { items: data, total: data.length };
+  if (Array.isArray(data)) return { items: data as Order[], total: data.length };
   if (data && typeof data === "object") {
-    const items = Array.isArray(data.items) ? data.items : [];
+    const obj = data as { items?: unknown; total?: unknown };
+    const items = Array.isArray(obj.items) ? (obj.items as Order[]) : [];
     const total =
-      typeof data.total === "number"
-        ? data.total
-        : (Array.isArray(data.items) ? data.items.length : undefined);
+      typeof obj.total === "number"
+        ? obj.total
+        : Array.isArray(obj.items)
+        ? obj.items.length
+        : undefined;
     return { items, total };
   }
   return { items: [], total: 0 };
 }
 
-export function getOrder(id: number | string) {
-  return request<any>(`/orders/${id}`);
+export function getOrder(id: number | string): Promise<Order> {
+  return request<Order>(`/orders/${id}`);
 }
 
 // Optional: tweak parsed payload before posting if your parser is loose
-function normalizeParsedForOrder(input: any) {
+function normalizeParsedForOrder(input: unknown): unknown {
   if (!input) return input;
-  // many backends return { ok, parsed }; accept both shapes safely
-  const parsed = input?.parsed ? input.parsed : input;
+  const obj = input as { parsed?: unknown };
+  const parsed = obj.parsed ?? input;
 
-  // Allow both "code" or "sku" mixups; do NOT force if already correct
-  if (parsed?.order) {
-    const order = parsed.order;
-    // If someone put order code into first item.sku by mistake, you could move it back here
-    // but only when order.code is empty.
-    if (!order.code && Array.isArray(order.items) && order.items.length) {
-      const guess = order.items.find((it: any) => it?.sku && typeof it.sku === "string");
-      if (guess && /^[A-Za-z]{1,3}\d{3,5}$/.test(guess.sku)) {
-        order.code = guess.sku;
-        guess.sku = null;
+  if (typeof parsed === "object" && parsed !== null && "order" in parsed) {
+    const order = (parsed as { order?: Record<string, unknown> }).order;
+    if (
+      order &&
+      !(order.code as unknown) &&
+      Array.isArray(order.items) &&
+      order.items.length
+    ) {
+      const guess = (order.items as Record<string, unknown>[]).find(
+        (it) => typeof it.sku === "string"
+      );
+      if (
+        guess &&
+        typeof guess.sku === "string" &&
+        /^[A-Za-z]{1,3}\d{3,5}$/.test(guess.sku)
+      ) {
+        order.code = guess.sku as string;
+        (guess as Record<string, unknown>).sku = null;
       }
     }
   }
   return parsed;
 }
 
-export async function createOrderFromParsed(parsed: any) {
-  const normalized = normalizeParsedForOrder(parsed);
-  const payload = normalized?.parsed ? normalized.parsed : normalized;
+export async function createOrderFromParsed(parsed: unknown): Promise<Order> {
+  const normalized = normalizeParsedForOrder(parsed) as {
+    parsed?: unknown;
+    customer?: Customer;
+    order?: Record<string, unknown>;
+  };
+  const payload = normalized.parsed
+    ? (normalized.parsed as Record<string, unknown>)
+    : normalized;
 
-  const customer = payload?.customer;
-  const order = payload?.order;
+  const customer = (payload as { customer?: Customer }).customer;
+  const order = (payload as { order?: Record<string, unknown> }).order;
 
   if (!customer || !order) {
-    throw new Error("Parsed payload missing {customer, order}. Please re-parse or edit JSON.");
+    throw new Error(
+      "Parsed payload missing {customer, order}. Please re-parse or edit JSON."
+    );
   }
 
   try {
-    // Primary: top-level {customer, order}
-    return await request<any>("/orders", { json: { customer, order } });
-  } catch (e: any) {
-    // Fallback: some backends accept { parsed: { customer, order } }
-    if (e?.status === 422 || e?.status === 400) {
-      return request<any>("/orders", { json: { parsed: { customer, order } } });
+    return await request<Order>("/orders", { json: { customer, order } });
+  } catch (e: unknown) {
+    const err = e as { status?: number };
+    if (err?.status === 422 || err?.status === 400) {
+      return request<Order>("/orders", { json: { parsed: { customer, order } } });
     }
     throw e;
   }
 }
 
-export function createManualOrder(payload: { customer: any; order: any }) {
-  return request<any>("/orders", { json: payload });
+export function createManualOrder(payload: {
+  customer: Customer;
+  order: Record<string, unknown>;
+}): Promise<Order> {
+  return request<Order>("/orders", { json: payload });
 }
 
-export function updateOrder(id: number, patch: any) {
-  return request<any>(`/orders/${id}`, { method: "PATCH", json: patch }).catch((e: any) => {
-    if (e?.status === 405) return request<any>(`/orders/${id}`, { method: "PUT", json: patch });
-    throw e;
-  });
+export function updateOrder(
+  id: number,
+  patch: Record<string, unknown>
+): Promise<Order> {
+  return request<Order>(`/orders/${id}`, { method: "PATCH", json: patch }).catch(
+    (e: unknown) => {
+      const err = e as { status?: number };
+      if (err?.status === 405)
+        return request<Order>(`/orders/${id}`, { method: "PUT", json: patch });
+      throw e;
+    }
+  );
 }
 
-export async function voidOrder(id: number, reason?: string) {
+export async function voidOrder(
+  id: number,
+  reason?: string
+): Promise<Order> {
   try {
-    return await request<any>(`/orders/${id}/void`, { json: { reason } });
-  } catch (e1: any) {
-    if (e1?.status === 404 || e1?.status === 405) {
+    return await request<Order>(`/orders/${id}/void`, { json: { reason } });
+  } catch (e1: unknown) {
+    const err1 = e1 as { status?: number };
+    if (err1?.status === 404 || err1?.status === 405) {
       try {
-        return await request<any>(`/orders/${id}/cancel`, { json: { reason } });
-      } catch (e2: any) {
-        if (e2?.status === 404 || e2?.status === 405)
-          return await updateOrder(id, { status: "CANCELLED", cancel_reason: reason || "" });
+        return await request<Order>(`/orders/${id}/cancel`, { json: { reason } });
+      } catch (e2: unknown) {
+        const err2 = e2 as { status?: number };
+        if (err2?.status === 404 || err2?.status === 405)
+          return await updateOrder(id, {
+            status: "CANCELLED",
+            cancel_reason: reason || "",
+          });
         throw e2;
       }
     }
@@ -164,19 +281,27 @@ export async function voidOrder(id: number, reason?: string) {
   }
 }
 
-export function markReturned(id: number, date?: string) {
-  const body: any = {};
+export function markReturned(
+  id: number,
+  date?: string
+): Promise<Order | { order: Order }> {
+  const body: Record<string, unknown> = {};
   if (date) body.date = date;
-  return request<any>(`/orders/${id}/return`, { json: body });
+  return request<Order | { order: Order }>(`/orders/${id}/return`, { json: body });
 }
 
-export function markBuyback(id: number, amount: number) {
-  return request<any>(`/orders/${id}/buyback`, { json: { amount } });
+export function markBuyback(
+  id: number,
+  amount: number
+): Promise<Order | { order: Order }> {
+  return request<Order | { order: Order }>(`/orders/${id}/buyback`, {
+    json: { amount },
+  });
 }
 
-export function orderDue(id: number, asOf?: string) {
+export function orderDue(id: number, asOf?: string): Promise<Due> {
   const qs = asOf ? `?as_of=${encodeURIComponent(asOf)}` : "";
-  return request<any>(`/orders/${id}/due${qs}`);
+  return request<Due>(`/orders/${id}/due${qs}`);
 }
 
 // -------- Payments
@@ -187,17 +312,17 @@ export function addPayment(payload: {
   method?: string;
   reference?: string;
   category?: string;
-}) {
-  return request<any>("/payments", { json: payload });
+}): Promise<Payment> {
+  return request<Payment>("/payments", { json: payload });
 }
-export function voidPayment(paymentId: number, reason?: string) {
-  return request<any>(`/payments/${paymentId}/void`, { json: { reason } });
+export function voidPayment(paymentId: number, reason?: string): Promise<Payment> {
+  return request<Payment>(`/payments/${paymentId}/void`, { json: { reason } });
 }
 
 // -------- Reports
 export function outstanding(type?: "INSTALLMENT" | "RENTAL") {
   const qs = type ? `?type=${encodeURIComponent(type)}` : "";
-  return request<{ items: any[] }>(`/reports/outstanding${qs}`);
+  return request<{ items: Order[] }>(`/reports/outstanding${qs}`);
 }
 
 // -------- Documents
@@ -205,3 +330,4 @@ export function invoicePdfUrl(orderId: number) {
   const base = API_BASE;
   return `${base}/documents/invoice/${orderId}.pdf`;
 }
+


### PR DESCRIPTION
## Summary
- add Order, Payment and other interfaces to shared API utilities
- return typed data from API helpers and update pages to use them

## Testing
- `npm run lint`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_b_68a83be3c83c832ea167ce943dba591e