### PR TITLE
feat: enable order parsing and orange theme

### DIFF
--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -2,3 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -3,10 +3,56 @@ import Layout from '@/components/Layout';
 import Card from '@/components/ui/Card';
 import Button from '@/components/ui/Button';
 import { useTranslation } from 'react-i18next';
+import { parseMessage, createOrderFromParsed } from '@/utils/api';
+
+function normalizeParsedForOrder(input: any) {
+  if (!input) return null;
+  const payload = typeof input === 'object' && 'parsed' in input ? input.parsed : input;
+  const core = payload && payload.data ? payload.data : payload;
+
+  if (core?.customer && core?.order) return { customer: core.customer, order: core.order };
+  if (!core) return null;
+  if (!core.customer && (core.order || core.items)) {
+    return { customer: core.customer || {}, order: core.order || core };
+  }
+  return core;
+}
 
 export default function IntakePage() {
   const { t } = useTranslation();
   const [text, setText] = React.useState('');
+  const [parsed, setParsed] = React.useState<any>(null);
+  const [busy, setBusy] = React.useState(false);
+  const [err, setErr] = React.useState('');
+  const [msg, setMsg] = React.useState('');
+
+  async function onParse() {
+    setBusy(true); setErr(''); setMsg('');
+    try {
+      const res = await parseMessage(text);
+      setParsed(res);
+      setMsg('Parsed successfully');
+    } catch (e: any) {
+      setErr(e?.message || 'Parse failed');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function onCreate() {
+    setBusy(true); setErr(''); setMsg('');
+    try {
+      const out = await createOrderFromParsed(parsed);
+      setMsg('Order created: ID ' + (out?.id || out?.order_id || JSON.stringify(out)));
+    } catch (e: any) {
+      setErr(e?.message || 'Create failed');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const toPost = normalizeParsedForOrder(parsed);
+
   return (
     <Layout>
       <div className="max-w-3xl mx-auto space-y-4">
@@ -18,10 +64,17 @@ export default function IntakePage() {
             onChange={(e) => setText(e.target.value)}
           />
           <div className="mt-4 flex justify-end gap-2">
-            <Button disabled={!text}>{t('intake.parse')}</Button>
-            <Button variant="secondary">{t('intake.create')}</Button>
+            <Button disabled={busy || !text} onClick={onParse}>{t('intake.parse')}</Button>
+            <Button variant="secondary" disabled={busy || !toPost} onClick={onCreate}>{t('intake.create')}</Button>
           </div>
+          {err && <p className="mt-2 text-danger-500 text-sm">{err}</p>}
+          {msg && <p className="mt-2 text-success-500 text-sm">{msg}</p>}
         </Card>
+        {toPost && (
+          <Card className="text-sm">
+            <pre className="whitespace-pre-wrap">{JSON.stringify(toPost, null, 2)}</pre>
+          </Card>
+        )}
       </div>
     </Layout>
   );

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -4,7 +4,7 @@
 
 @layer base {
   body {
-    background-color: #f3f8ff;
+    background-color: #fff7ed;
     color: #0b1220;
     font-family: ui-sans-serif, system-ui, sans-serif;
   }

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -5,8 +5,8 @@ const config: Config = {
   theme: {
     extend: {
       colors: {
-        brand: { 50: '#f3f8ff', 100: '#e6f0ff', 500: '#3b82f6', 600: '#2563eb' },
-        accent: { 500: '#f59e0b', 600: '#d97706' },
+        brand: { 50: '#fff7ed', 100: '#ffedd5', 500: '#f97316', 600: '#ea580c' },
+        accent: { 500: '#fb923c', 600: '#f97316' },
         success: { 500: '#16a34a' },
         warning: { 500: '#f59e0b' },
         danger: { 500: '#ef4444' },

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -22,7 +22,8 @@
       "@/*": [
         "*"
       ]
-    }
+    },
+    "types": ["vitest/globals"]
   },
   "include": [
     "next-env.d.ts",


### PR DESCRIPTION
## Summary
- connect intake page buttons to parsing and order creation APIs
- refresh UI with an orange brand palette
- configure TypeScript for vitest tests

## Testing
- `npm run lint`
- `npx tsc --noEmit`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a870fa3a7c832e95db25e4266be5f3