### PR TITLE
Modernize frontend styling with gradients and icons

### DIFF
--- a/frontend/components/Layout.tsx
+++ b/frontend/components/Layout.tsx
@@ -2,24 +2,37 @@ import Link from 'next/link';
 import React from 'react';
 import LanguageSwitcher from './LanguageSwitcher';
 import { useTranslation } from 'react-i18next';
+import { Inbox, Workflow } from 'lucide-react';
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   const { t } = useTranslation();
+  const nav = [
+    { href: '/', label: t('nav.intake'), Icon: Inbox },
+    { href: '/ops', label: t('nav.ops'), Icon: Workflow },
+  ];
   return (
-    <div className="min-h-screen flex flex-col">
-      <header className="bg-brand-500 text-white px-4 py-3 flex items-center justify-between gap-4">
-        <h1 className="text-xl font-semibold">OrderOps</h1>
-        <nav className="flex gap-4">
-          <Link href="/" className="hover:underline">
-            {t('nav.intake')}
-          </Link>
-          <Link href="/ops" className="hover:underline">
-            {t('nav.ops')}
-          </Link>
-        </nav>
-        <LanguageSwitcher />
+    <div className="flex min-h-screen flex-col">
+      <header className="sticky top-0 z-10 bg-gradient-to-r from-brand-500 to-accent-500 text-white shadow-md">
+        <div className="mx-auto flex max-w-5xl items-center justify-between gap-4 px-4 py-3">
+          <h1 className="text-xl font-semibold">OrderOps</h1>
+          <nav className="flex items-center gap-6">
+            {nav.map(({ href, label, Icon }) => (
+              <Link
+                key={href}
+                href={href}
+                className="flex items-center gap-1 text-sm font-medium transition-colors hover:text-white/80"
+              >
+                <Icon className="h-5 w-5" />
+                <span>{label}</span>
+              </Link>
+            ))}
+          </nav>
+          <LanguageSwitcher />
+        </div>
       </header>
-      <main className="flex-1 p-4 bg-brand-50">{children}</main>
+      <main className="flex-1 bg-gradient-to-br from-brand-50 to-white p-6">
+        <div className="mx-auto max-w-5xl">{children}</div>
+      </main>
     </div>
   );
 }

--- a/frontend/components/ui/Button.tsx
+++ b/frontend/components/ui/Button.tsx
@@ -6,10 +6,11 @@ export type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
 };
 
 export default function Button({ variant = 'primary', className, ...props }: ButtonProps) {
-  const base = 'px-4 py-2 rounded-lg font-medium focus:outline-none focus:ring-2 focus:ring-offset-2';
+  const base =
+    'inline-flex items-center justify-center rounded-xl px-4 py-2 font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2';
   const styles =
     variant === 'secondary'
-      ? 'bg-ink-200 text-ink-900 hover:bg-ink-400 focus:ring-ink-400'
-      : 'bg-brand-500 text-white hover:bg-brand-600 focus:ring-brand-500';
+      ? 'bg-white/80 text-ink-900 shadow-sm hover:bg-white focus:ring-ink-400'
+      : 'bg-gradient-to-r from-brand-500 to-accent-500 text-white shadow-md hover:from-brand-600 hover:to-accent-600 focus:ring-brand-500';
   return <button className={clsx(base, styles, className)} {...props} />;
 }

--- a/frontend/components/ui/Card.tsx
+++ b/frontend/components/ui/Card.tsx
@@ -2,5 +2,7 @@ import React from 'react';
 import clsx from 'clsx';
 
 export default function Card({ children, className }: { children: React.ReactNode; className?: string }) {
-  return <div className={clsx('bg-white rounded-xl shadow-sm p-4', className)}>{children}</div>;
+  return (
+    <div className={clsx('rounded-2xl bg-white/70 p-6 shadow-lg backdrop-blur', className)}>{children}</div>
+  );
 }

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -1,7 +1,14 @@
 import type { AppProps } from 'next/app';
+import { Inter } from 'next/font/google';
 import '@/styles/globals.css';
 import '@/i18n';
 
+const inter = Inter({ subsets: ['latin'] });
+
 export default function App({ Component, pageProps }: AppProps) {
-  return <Component {...pageProps} />;
+  return (
+    <div className={inter.className}>
+      <Component {...pageProps} />
+    </div>
+  );
 }

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -55,20 +55,20 @@ export default function IntakePage() {
 
   return (
     <Layout>
-      <div className="max-w-3xl mx-auto space-y-4">
+      <div className="mx-auto max-w-3xl space-y-6">
         <Card>
           <textarea
-            className="w-full h-40 p-3 border border-ink-200 rounded-xl"
+            className="h-40 w-full rounded-2xl border border-ink-200 bg-white/70 p-3 shadow-inner focus:border-brand-500 focus:outline-none focus:ring-2 focus:ring-brand-500"
             placeholder={t('intake.placeholder')}
             value={text}
             onChange={(e) => setText(e.target.value)}
           />
-          <div className="mt-4 flex justify-end gap-2">
+          <div className="mt-4 flex justify-end gap-3">
             <Button disabled={busy || !text} onClick={onParse}>{t('intake.parse')}</Button>
             <Button variant="secondary" disabled={busy || !toPost} onClick={onCreate}>{t('intake.create')}</Button>
           </div>
-          {err && <p className="mt-2 text-danger-500 text-sm">{err}</p>}
-          {msg && <p className="mt-2 text-success-500 text-sm">{msg}</p>}
+          {err && <p className="mt-2 text-sm text-danger-500">{err}</p>}
+          {msg && <p className="mt-2 text-sm text-success-500">{msg}</p>}
         </Card>
         {toPost && (
           <Card className="text-sm">

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -4,8 +4,6 @@
 
 @layer base {
   body {
-    background-color: #fff7ed;
-    color: #0b1220;
-    font-family: ui-sans-serif, system-ui, sans-serif;
+    @apply bg-gradient-to-br from-brand-50 to-white text-ink-900 antialiased;
   }
 }


### PR DESCRIPTION
## Summary
- Refresh layout with gradient header, responsive container, and navigation icons
- Introduce Inter font and gradient background for modern feel
- Enhance buttons, cards, and intake page elements with contemporary styling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a875591fcc832eb784ce584d5ab219