### PR TITLE
Enforce strict JSON schema for order parser

### DIFF
--- a/backend/app/services/parser.py
+++ b/backend/app/services/parser.py
@@ -23,6 +23,7 @@ SCHEMA = {
                 "map_url": {"type": "string"},
             },
             "required": ["name"],
+            "additionalProperties": False,
         },
         "order": {
             "type": "object",
@@ -56,6 +57,7 @@ SCHEMA = {
                             "line_total",
                             "item_type",
                         ],
+                        "additionalProperties": False,
                     },
                 },
                 "charges": {
@@ -66,6 +68,7 @@ SCHEMA = {
                         "penalty_fee": {"type": "number"},
                         "discount": {"type": "number"},
                     },
+                    "additionalProperties": False,
                 },
                 "plan": {
                     "type": "object",
@@ -74,6 +77,7 @@ SCHEMA = {
                         "months": {"type": "integer"},
                         "monthly_amount": {"type": "number"},
                     },
+                    "additionalProperties": False,
                 },
                 "totals": {
                     "type": "object",
@@ -83,12 +87,15 @@ SCHEMA = {
                         "paid": {"type": "number"},
                         "to_collect": {"type": "number"},
                     },
+                    "additionalProperties": False,
                 },
             },
             "required": ["type"],
+            "additionalProperties": False,
         },
     },
     "required": ["customer", "order"],
+    "additionalProperties": False,
 }
 
 


### PR DESCRIPTION
## Summary
- Ensure all schema objects in parser disallow unknown fields by setting `additionalProperties: false`

## Testing
- `cd backend && pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`

------
https://chatgpt.com/codex/tasks/task_b_68a876eea388832ea707ceef2d7da49c