### PR TITLE
feat: support outstanding report filters

### DIFF
--- a/backend/app/routers/reports.py
+++ b/backend/app/routers/reports.py
@@ -1,45 +1,86 @@
-from fastapi import APIRouter, Depends, Query
-from sqlalchemy.orm import Session
-from datetime import datetime
+from datetime import date, datetime
 from decimal import Decimal
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
 from ..db import get_session
-from ..models import Order
-from ..services.plan_math import calculate_plan_due
+from ..models import Order, Payment
+from ..services.plan_math import months_elapsed
+
 
 router = APIRouter(prefix="/reports", tags=["reports"])
 
+
 @router.get("/outstanding", response_model=dict)
-def outstanding(type: str | None = Query(default=None), db: Session = Depends(get_session)):
-    """Return outstanding balances for orders.
+def outstanding(
+    order_type: str = Query(default="ALL", alias="type"),
+    as_of: date | None = Query(default=None),
+    exclude_cleared: bool = Query(default=True),
+    db: Session = Depends(get_session),
+):
+    """Return outstanding balances for orders as of ``as_of`` date."""
 
-    The payload is normalized to ``{"items": [...]}`` where each item contains
-    ``id``, ``code``, ``customer`` (object with ``name``), ``type``, ``status``
-    and ``balance``.  An optional ``type`` query parameter can be supplied to
-    filter by order type.
-    """
-
-    today = datetime.utcnow().date()
+    as_of = as_of or date.today()
+    end_dt = datetime.combine(as_of, datetime.min.time())
     rows = db.query(Order).all()
     items: list[dict] = []
 
     for o in rows:
-        if type and o.type != type:
+        if order_type and order_type != "ALL" and o.type != order_type:
             continue
-        if not o.delivery_date:
+        if not o.delivery_date or o.delivery_date.date() > as_of:
             continue
 
-        paid = Decimal(o.paid_amount or 0)
+        if exclude_cleared:
+            if o.status == "RETURNED":
+                continue
+            if o.status == "CANCELLED" and (o.penalty_fee or 0) > 0:
+                continue
 
-        if o.type in ("INSTALLMENT", "RENTAL") and o.plan:
-            # Amount expected to be paid as of today plus any additional fees
-            expected = calculate_plan_due(o.plan, today)
-            fees = (o.delivery_fee or 0) + (o.return_delivery_fee or 0) + (o.penalty_fee or 0)
-            expected += Decimal(str(fees))
-        else:
-            # For outright and other orders rely on stored total
-            expected = Decimal(o.total or 0)
+        expected = Decimal("0.00")
+        months = months_elapsed(o.delivery_date, end_dt)
+        for it in o.items:
+            t = (it.item_type or "").upper()
+            if t == "OUTRIGHT":
+                price = it.line_total or (it.unit_price or 0) * (it.qty or 0)
+                expected += Decimal(str(price))
+            elif t in {"INSTALLMENT", "RENTAL"}:
+                monthly = Decimal(str(it.unit_price or it.line_total or 0))
+                m = months
+                if (
+                    t == "INSTALLMENT"
+                    and getattr(o, "plan", None)
+                    and o.plan.months  # noqa: E501
+                ):
+                    try:
+                        m = min(m, int(o.plan.months))
+                    except Exception:
+                        pass
+                expected += monthly * Decimal(m)
+            # FEE or other items ignored here
 
-        bal = (expected - paid).quantize(Decimal("0.01"))
+        fees = Decimal(
+            str(
+                (o.delivery_fee or 0)
+                + (o.return_delivery_fee or 0)
+                + (o.penalty_fee or 0)
+            )
+        )
+
+        paid = (
+            db.query(func.coalesce(func.sum(Payment.amount), 0))
+            .filter(Payment.order_id == o.id)
+            .filter(Payment.status == "POSTED")
+            .filter(Payment.date <= as_of)
+            .scalar()
+        )
+        paid = Decimal(str(paid))
+
+        bal = (expected + fees - paid).quantize(Decimal("0.01"))
+        if bal <= 0:
+            continue
 
         items.append(
             {
@@ -48,8 +89,15 @@ def outstanding(type: str | None = Query(default=None), db: Session = Depends(ge
                 "customer": {"name": getattr(o.customer, "name", "")},
                 "type": o.type,
                 "status": o.status,
+                "expected": float(expected),
+                "paid": float(paid),
+                "fees": float(fees),
                 "balance": float(bal),
             }
         )
 
-    return {"items": items}
+    totals = {
+        k: float(sum(Decimal(str(it[k])) for it in items))
+        for k in ("expected", "paid", "fees", "balance")
+    }
+    return {"as_of": str(as_of), "items": items, "totals": totals}

--- a/frontend/pages/reports/outstanding.tsx
+++ b/frontend/pages/reports/outstanding.tsx
@@ -6,8 +6,9 @@ import { outstanding } from "@/utils/api";
 import Link from "next/link";
 
 export default function OutstandingPage() {
-  const [tab, setTab] = React.useState<"INSTALLMENT" | "RENTAL">(
-    "INSTALLMENT"
+  const [type, setType] = React.useState<string>("ALL");
+  const [asOf, setAsOf] = React.useState<string>(() =>
+    new Date().toISOString().slice(0, 10)
   );
   const [rows, setRows] = React.useState<any[]>([]);
   const [loading, setLoading] = React.useState(false);
@@ -15,33 +16,55 @@ export default function OutstandingPage() {
   const load = React.useCallback(async () => {
     setLoading(true);
     try {
-      const r = await outstanding(tab);
+      const r = await outstanding(type, asOf);
       setRows(r.items || []);
     } catch (e) {
       console.error(e);
     }
     setLoading(false);
-  }, [tab]);
+  }, [type, asOf]);
 
   React.useEffect(() => {
     load();
   }, [load]);
+
   return (
     <Layout>
       <div className="container stack" style={{ maxWidth: '64rem' }}>
         <Card>
           <h2 style={{ marginTop: 0, marginBottom: 16 }}>Outstanding</h2>
-          <div style={{ display: 'flex', gap: 8, marginBottom: 16 }}>
-            <Button onClick={() => setTab('INSTALLMENT')} disabled={tab === 'INSTALLMENT'}>
-              Installments
-            </Button>
-            <Button
-              variant="secondary"
-              onClick={() => setTab('RENTAL')}
-              disabled={tab === 'RENTAL'}
-            >
-              Rentals
-            </Button>
+          <div
+            style={{
+              display: 'flex',
+              gap: 8,
+              marginBottom: 16,
+              flexWrap: 'wrap',
+              alignItems: 'center',
+            }}
+          >
+            <label>
+              Type:
+              <select
+                value={type}
+                onChange={(e) => setType(e.target.value)}
+                style={{ marginLeft: 4 }}
+              >
+                <option value="ALL">All</option>
+                <option value="OUTRIGHT">Outright</option>
+                <option value="INSTALLMENT">Installment</option>
+                <option value="RENTAL">Rental</option>
+                <option value="MIXED">Mixed</option>
+              </select>
+            </label>
+            <label>
+              As of:
+              <input
+                type="date"
+                value={asOf}
+                onChange={(e) => setAsOf(e.target.value)}
+                style={{ marginLeft: 4 }}
+              />
+            </label>
             <Button variant="secondary" onClick={load} disabled={loading}>
               {loading ? 'Refreshing...' : 'Refresh'}
             </Button>
@@ -54,6 +77,9 @@ export default function OutstandingPage() {
                   <th>Customer</th>
                   <th>Type</th>
                   <th>Status</th>
+                  <th>Expected</th>
+                  <th>Paid</th>
+                  <th>Fees</th>
                   <th>Balance</th>
                 </tr>
               </thead>
@@ -69,13 +95,22 @@ export default function OutstandingPage() {
                       <span className="badge">{r.status}</span>
                     </td>
                     <td style={{ textAlign: 'right' }}>
+                      RM {Number(r.expected || 0).toFixed(2)}
+                    </td>
+                    <td style={{ textAlign: 'right' }}>
+                      RM {Number(r.paid || 0).toFixed(2)}
+                    </td>
+                    <td style={{ textAlign: 'right' }}>
+                      RM {Number(r.fees || 0).toFixed(2)}
+                    </td>
+                    <td style={{ textAlign: 'right' }}>
                       RM {Number(r.balance || 0).toFixed(2)}
                     </td>
                   </tr>
                 ))}
                 {rows.length === 0 && (
                   <tr>
-                    <td colSpan={5} style={{ opacity: 0.7 }}>
+                    <td colSpan={8} style={{ opacity: 0.7 }}>
                       No data
                     </td>
                   </tr>

--- a/frontend/utils/api.ts
+++ b/frontend/utils/api.ts
@@ -195,9 +195,12 @@ export function voidPayment(paymentId: number, reason?: string) {
 }
 
 // -------- Reports
-export function outstanding(type?: "INSTALLMENT" | "RENTAL") {
-  const qs = type ? `?type=${encodeURIComponent(type)}` : "";
-  return request<{ items: any[] }>(`/reports/outstanding${qs}`);
+export function outstanding(type?: string, asOf?: string) {
+  const sp = new URLSearchParams();
+  if (type && type !== "ALL") sp.set("type", type);
+  if (asOf) sp.set("as_of", asOf);
+  const qs = sp.toString();
+  return request<{ items: any[] }>(`/reports/outstanding${qs ? `?${qs}` : ""}`);
 }
 
 // -------- Documents


### PR DESCRIPTION
## Summary
- expand /reports/outstanding to handle mixed order types, as-of date filtering and payments cutoff
- add API helper parameters and UI controls for type and as-of, showing expected/paid/fees/balance columns

## Testing
- `black --check .` *(fails: would reformat many files)*
- `flake8 .` *(fails: numerous style errors)*
- `mypy .` *(fails: missing types and attribute errors)*
- `pytest --cov=app`
- `npm run lint`
- `npx tsc --noEmit`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a88b163d68832e9b36c77ac707c420