### PR TITLE
Fix order creation parsing and preserve delivery date on returns

### DIFF
--- a/backend/app/models/order.py
+++ b/backend/app/models/order.py
@@ -14,6 +14,7 @@ class Order(Base):
     status: Mapped[str] = mapped_column(String(20), default="NEW")  # NEW|ACTIVE|RETURNED|CANCELLED|COMPLETED
     customer_id: Mapped[int] = mapped_column(ForeignKey("customers.id"), nullable=False)
     delivery_date: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    returned_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     notes: Mapped[str | None] = mapped_column(Text, nullable=True)
 
     subtotal: Mapped[Decimal] = mapped_column(Numeric(12, 2), default=Decimal("0.00"))

--- a/backend/app/routers/parse.py
+++ b/backend/app/routers/parse.py
@@ -183,8 +183,8 @@ def parse_message(body: ParseIn, db: Session = Depends(get_session)):
     created = {}
     if body.create_order:
         try:
-            order_id, code = create_from_parsed(parsed, db)
-            created = {"order_id": order_id, "code": code}
+            order = create_from_parsed(db, parsed)
+            created = {"order_id": order.id, "code": order.code}
         except HTTPException:
             raise
         except Exception as e:

--- a/backend/app/services/status_updates.py
+++ b/backend/app/services/status_updates.py
@@ -42,8 +42,7 @@ def mark_cancelled(db: Session, order: Order, reason: str | None = None) -> Orde
 
 def mark_returned(db: Session, order: Order, return_date: datetime | None = None) -> Order:
     """Mark an order as returned, optionally recording a return date."""
-    if return_date:
-        order.delivery_date = return_date
+    order.returned_at = return_date or datetime.utcnow()
     order.status = "RETURNED"
     recompute_financials(order)
     db.commit()


### PR DESCRIPTION
## Summary
- Correct parse router to call create_from_parsed with correct signature and return order object
- Add returned_at column to Order and track return time without mutating delivery_date
- Update status_updates.mark_returned to set returned_at instead of delivery_date

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a8989b7a28832e8b84d62e45663865