### PR TITLE
Use Decimal for monetary fields and optimize outstanding report

### DIFF
--- a/backend/app/models/order_item.py
+++ b/backend/app/models/order_item.py
@@ -1,5 +1,8 @@
+from decimal import Decimal
+
 from sqlalchemy import BigInteger, DateTime, String, Numeric, ForeignKey, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
+
 from .base import Base
 
 class OrderItem(Base):
@@ -11,5 +14,5 @@ class OrderItem(Base):
     category: Mapped[str | None] = mapped_column(String(50))  # BED | WHEELCHAIR | OXYGEN | ACCESSORY
     item_type: Mapped[str] = mapped_column(String(20))  # OUTRIGHT|INSTALLMENT|RENTAL|FEE
     qty: Mapped[int] = mapped_column(Numeric(12,0), default=1)
-    unit_price: Mapped[float] = mapped_column(Numeric(12,2), default=0)
-    line_total: Mapped[float] = mapped_column(Numeric(12,2), default=0)
+    unit_price: Mapped[Decimal] = mapped_column(Numeric(12, 2), default=0)
+    line_total: Mapped[Decimal] = mapped_column(Numeric(12, 2), default=0)

--- a/backend/app/models/payment.py
+++ b/backend/app/models/payment.py
@@ -1,7 +1,9 @@
 from datetime import date, datetime
+from decimal import Decimal
 
 from sqlalchemy import BigInteger, Date, String, Numeric, ForeignKey, DateTime, func, Text
 from sqlalchemy.orm import Mapped, mapped_column
+
 from .base import Base
 
 class Payment(Base):
@@ -9,7 +11,7 @@ class Payment(Base):
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
     order_id: Mapped[int] = mapped_column(ForeignKey("orders.id"), nullable=False, index=True)
     date: Mapped[date] = mapped_column(Date, nullable=False)
-    amount: Mapped[float] = mapped_column(Numeric(12,2), nullable=False)
+    amount: Mapped[Decimal] = mapped_column(Numeric(12, 2), nullable=False)
     method: Mapped[str | None] = mapped_column(String(30), nullable=True)  # cash/transfer/cheque/etc
     reference: Mapped[str | None] = mapped_column(String(100), nullable=True)
     category: Mapped[str] = mapped_column(String(20), default="ORDER")  # ORDER|RENTAL|INSTALLMENT|PENALTY|DELIVERY|BUYBACK

--- a/backend/app/models/plan.py
+++ b/backend/app/models/plan.py
@@ -1,5 +1,8 @@
+from decimal import Decimal
+
 from sqlalchemy import BigInteger, Date, String, Numeric, ForeignKey
 from sqlalchemy.orm import Mapped, mapped_column
+
 from .base import Base
 
 class Plan(Base):
@@ -8,6 +11,6 @@ class Plan(Base):
     order_id: Mapped[int] = mapped_column(ForeignKey("orders.id"), nullable=False)
     plan_type: Mapped[str] = mapped_column(String(20))  # RENTAL | INSTALLMENT
     start_date: Mapped[str | None] = mapped_column(Date, nullable=True)
-    months: Mapped[int | None] = mapped_column(Numeric(12,0), nullable=True)  # For installment
-    monthly_amount: Mapped[float] = mapped_column(Numeric(12,2), default=0)
+    months: Mapped[int | None] = mapped_column(Numeric(12, 0), nullable=True)  # For installment
+    monthly_amount: Mapped[Decimal] = mapped_column(Numeric(12, 2), default=0)
     status: Mapped[str] = mapped_column(String(20), default="ACTIVE")  # ACTIVE|CANCELLED|COMPLETED

--- a/backend/app/routers/payments.py
+++ b/backend/app/routers/payments.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 from datetime import date
+from decimal import Decimal
+
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
@@ -8,12 +10,13 @@ from sqlalchemy.orm import Session
 from ..db import get_session
 from ..models import Payment, Order
 from ..utils.normalize import to_decimal
+from ..services.status_updates import recompute_financials
 
 router = APIRouter(prefix="/payments", tags=["payments"])
 
 class PaymentIn(BaseModel):
     order_id: int
-    amount: float
+    amount: Decimal
     date: str | None = None
     method: str | None = None
     reference: str | None = None
@@ -26,10 +29,17 @@ def add_payment(body: PaymentIn, db: Session = Depends(get_session)):
         raise HTTPException(404, "Order not found")
     pdate = date.fromisoformat(body.date) if body.date else date.today()
     amount = to_decimal(body.amount)
-    p = Payment(order_id=order.id, amount=amount, date=pdate, method=body.method, reference=body.reference, category=body.category or "ORDER")
+    p = Payment(
+        order_id=order.id,
+        amount=amount,
+        date=pdate,
+        method=body.method,
+        reference=body.reference,
+        category=body.category or "ORDER",
+    )
     db.add(p)
     order.paid_amount = to_decimal(order.paid_amount) + amount
-    order.balance = to_decimal(order.total) - to_decimal(order.paid_amount)
+    recompute_financials(order)
     db.commit()
     db.refresh(order)
     return {"payment_id": p.id, "order_balance": float(order.balance)}
@@ -48,7 +58,7 @@ def void_payment(payment_id: int, body: VoidIn, db: Session = Depends(get_sessio
     p.void_reason = body.reason or ""
     order = db.get(Order, p.order_id)
     order.paid_amount = to_decimal(order.paid_amount) - to_decimal(p.amount)
-    order.balance = to_decimal(order.total) - to_decimal(order.paid_amount)
+    recompute_financials(order)
     db.commit()
     db.refresh(order)
     return {"ok": True, "status": "VOIDED", "order_balance": float(order.balance)}

--- a/backend/app/routers/reports.py
+++ b/backend/app/routers/reports.py
@@ -2,11 +2,11 @@ from datetime import date, datetime
 from decimal import Decimal
 
 from fastapi import APIRouter, Depends, Query
-from sqlalchemy import func
+from sqlalchemy import Integer, and_, cast, case, func, select
 from sqlalchemy.orm import Session
 
 from ..db import get_session
-from ..models import Order, Payment
+from ..models import Customer, Order, OrderItem, Payment, Plan
 from ..services.plan_math import months_elapsed
 
 
@@ -18,77 +18,146 @@ def outstanding(
     order_type: str = Query(default="ALL", alias="type"),
     as_of: date | None = Query(default=None),
     exclude_cleared: bool = Query(default=True),
+    limit: int = Query(50, ge=1, le=1000),
+    offset: int = Query(0, ge=0),
     db: Session = Depends(get_session),
 ):
     """Return outstanding balances for orders as of ``as_of`` date."""
 
     as_of = as_of or date.today()
     end_dt = datetime.combine(as_of, datetime.min.time())
-    rows = db.query(Order).all()
-    items: list[dict] = []
 
-    for o in rows:
-        if order_type and order_type != "ALL" and o.type != order_type:
-            continue
-        if not o.delivery_date or o.delivery_date.date() > as_of:
-            continue
-
-        if exclude_cleared:
-            if o.status == "RETURNED":
-                continue
-            if o.status == "CANCELLED" and (o.penalty_fee or 0) > 0:
-                continue
-
-        expected = Decimal("0.00")
-        months = months_elapsed(o.delivery_date, end_dt)
-        for it in o.items:
-            t = (it.item_type or "").upper()
-            if t == "OUTRIGHT":
-                price = it.line_total or (it.unit_price or 0) * (it.qty or 0)
-                expected += Decimal(str(price))
-            elif t in {"INSTALLMENT", "RENTAL"}:
-                monthly = Decimal(str(it.unit_price or it.line_total or 0))
-                m = months
-                if (
-                    t == "INSTALLMENT"
-                    and getattr(o, "plan", None)
-                    and o.plan.months  # noqa: E501
-                ):
-                    try:
-                        m = min(m, int(o.plan.months))
-                    except Exception:
-                        pass
-                expected += monthly * Decimal(m)
-            # FEE or other items ignored here
-
-        fees = Decimal(
-            str(
-                (o.delivery_fee or 0)
-                + (o.return_delivery_fee or 0)
-                + (o.penalty_fee or 0)
+    paid_subq = (
+        select(func.coalesce(func.sum(Payment.amount), 0))
+            .where(
+                Payment.order_id == Order.id,
+                Payment.status == "POSTED",
+                Payment.date <= as_of,
             )
-        )
+            .correlate(Order)
+            .scalar_subquery()
+    )
 
-        paid = (
-            db.query(func.coalesce(func.sum(Payment.amount), 0))
-            .filter(Payment.order_id == o.id)
-            .filter(Payment.status == "POSTED")
-            .filter(Payment.date <= as_of)
-            .scalar()
-        )
-        paid = Decimal(str(paid))
+    months_elapsed_expr = cast(
+        (func.julianday(as_of) - func.julianday(Order.delivery_date)) / 30.0,
+        Integer,
+    )
+    months_expr = case(
+        (Plan.months != None, func.min(Plan.months, months_elapsed_expr)),
+        else_=months_elapsed_expr,
+    )
 
+    outright_expr = func.coalesce(
+        func.sum(
+            case(
+                (OrderItem.item_type == "OUTRIGHT",
+                 func.coalesce(OrderItem.line_total, OrderItem.unit_price * OrderItem.qty)),
+                else_=0,
+            )
+        ),
+        0,
+    )
+    monthly_expr = func.coalesce(
+        func.sum(
+            case(
+                (OrderItem.item_type.in_(["INSTALLMENT", "RENTAL"]),
+                 func.coalesce(OrderItem.unit_price, OrderItem.line_total, 0)),
+                else_=0,
+            )
+        ),
+        0,
+    )
+
+    expected_expr = outright_expr + monthly_expr * months_expr
+    fees_expr = (
+        func.coalesce(Order.delivery_fee, 0)
+        + func.coalesce(Order.return_delivery_fee, 0)
+        + func.coalesce(Order.penalty_fee, 0)
+    )
+    balance_expr = expected_expr + fees_expr - paid_subq
+
+    stmt = (
+        select(
+            Order.id,
+            Order.code,
+            Order.type,
+            Order.status,
+            Customer.name.label("customer_name"),
+            expected_expr.label("expected"),
+            fees_expr.label("fees"),
+            paid_subq.label("paid"),
+            balance_expr.label("balance"),
+        )
+        .join(Customer, Customer.id == Order.customer_id)
+        .outerjoin(OrderItem, OrderItem.order_id == Order.id)
+        .outerjoin(Plan, Plan.order_id == Order.id)
+        .where(Order.delivery_date != None)
+        .where(Order.delivery_date <= as_of)
+    )
+
+    if order_type and order_type != "ALL":
+        stmt = stmt.where(Order.type == order_type)
+
+    if exclude_cleared:
+        stmt = stmt.where(Order.status != "RETURNED")
+        stmt = stmt.where(~and_(Order.status == "CANCELLED", Order.penalty_fee > 0))
+
+    stmt = stmt.group_by(
+        Order.id,
+        Order.code,
+        Order.type,
+        Order.status,
+        Customer.name,
+        Order.delivery_fee,
+        Order.return_delivery_fee,
+        Order.penalty_fee,
+        Plan.months,
+        Order.delivery_date,
+    )
+    stmt = stmt.order_by(balance_expr.desc()).limit(limit).offset(offset)
+
+    rows = db.execute(stmt).all()
+    items: list[dict] = []
+    for row in rows:
+        expected = Decimal(str(row.expected or 0))
+        fees = Decimal(str(row.fees or 0))
+        paid = Decimal(str(row.paid or 0))
         bal = (expected + fees - paid).quantize(Decimal("0.01"))
+
+        if row.type == "MIXED":  # Fallback for complex cases
+            o = db.get(Order, row.id)
+            months = months_elapsed(o.delivery_date, end_dt)
+            expected = Decimal("0")
+            for it in o.items:
+                t = (it.item_type or "").upper()
+                if t == "OUTRIGHT":
+                    price = it.line_total or (it.unit_price or 0) * (it.qty or 0)
+                    expected += Decimal(str(price))
+                elif t in {"INSTALLMENT", "RENTAL"}:
+                    monthly = Decimal(str(it.unit_price or it.line_total or 0))
+                    m = months
+                    if (
+                        t == "INSTALLMENT"
+                        and getattr(o, "plan", None)
+                        and o.plan.months
+                    ):
+                        try:
+                            m = min(m, int(o.plan.months))
+                        except Exception:
+                            pass
+                    expected += monthly * Decimal(m)
+            bal = (expected + fees - paid).quantize(Decimal("0.01"))
+
         if bal <= 0:
             continue
 
         items.append(
             {
-                "id": o.id,
-                "code": o.code,
-                "customer": {"name": getattr(o.customer, "name", "")},
-                "type": o.type,
-                "status": o.status,
+                "id": row.id,
+                "code": row.code,
+                "customer": {"name": row.customer_name},
+                "type": row.type,
+                "status": row.status,
                 "expected": float(expected),
                 "paid": float(paid),
                 "fees": float(fees),
@@ -101,3 +170,4 @@ def outstanding(
         for k in ("expected", "paid", "fees", "balance")
     }
     return {"as_of": str(as_of), "items": items, "totals": totals}
+

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,5 +1,7 @@
-from pydantic import BaseModel, Field
+from decimal import Decimal
 from typing import Optional, List
+
+from pydantic import BaseModel, Field
 import datetime as dt
 
 class CustomerIn(BaseModel):
@@ -13,27 +15,27 @@ class ItemIn(BaseModel):
     sku: Optional[str] = None
     category: Optional[str] = None  # BED|WHEELCHAIR|OXYGEN|ACCESSORY
     item_type: str  # OUTRIGHT|INSTALLMENT|RENTAL|FEE
-    qty: float = 1
-    unit_price: float = 0
-    line_total: float = 0
+    qty: Decimal = Decimal("1")
+    unit_price: Decimal = Decimal("0")
+    line_total: Decimal = Decimal("0")
 
 class PlanIn(BaseModel):
     plan_type: str  # RENTAL|INSTALLMENT
     months: Optional[int] = None
-    monthly_amount: float = 0
+    monthly_amount: Decimal = Decimal("0")
     start_date: Optional[str] = None
 
 class ChargesIn(BaseModel):
-    delivery_fee: float = 0
-    return_delivery_fee: float = 0
-    penalty_fee: float = 0
-    discount: float = 0
+    delivery_fee: Decimal = Decimal("0")
+    return_delivery_fee: Decimal = Decimal("0")
+    penalty_fee: Decimal = Decimal("0")
+    discount: Decimal = Decimal("0")
 
 class TotalsIn(BaseModel):
-    subtotal: float = 0
-    total: float = 0
-    paid: float = 0
-    to_collect: float = 0
+    subtotal: Decimal = Decimal("0")
+    total: Decimal = Decimal("0")
+    paid: Decimal = Decimal("0")
+    to_collect: Decimal = Decimal("0")
 
 class OrderBlock(BaseModel):
     type: str  # OUTRIGHT|INSTALLMENT|RENTAL|MIXED
@@ -68,9 +70,9 @@ class OrderItemOut(BaseModel):
     sku: Optional[str] = None
     category: Optional[str] = None
     item_type: str
-    qty: float
-    unit_price: float
-    line_total: float
+    qty: Decimal
+    unit_price: Decimal
+    line_total: Decimal
 
     class Config:
         from_attributes = True
@@ -78,7 +80,7 @@ class OrderItemOut(BaseModel):
 
 class PaymentOut(BaseModel):
     id: int
-    amount: float
+    amount: Decimal
     date: Optional[dt.date] = None
     method: Optional[str] = None
     reference: Optional[str] = None
@@ -93,7 +95,7 @@ class PlanOut(BaseModel):
     plan_type: str
     start_date: Optional[dt.date] = None
     months: Optional[int] = None
-    monthly_amount: float = 0
+    monthly_amount: Decimal = Decimal("0")
     status: str
 
     class Config:
@@ -107,14 +109,14 @@ class OrderOut(BaseModel):
     status: str
     delivery_date: Optional[dt.date] = None
     notes: Optional[str] = None
-    subtotal: float
-    discount: float | None = 0
-    delivery_fee: float | None = 0
-    return_delivery_fee: float | None = 0
-    penalty_fee: float | None = 0
-    total: float
-    paid_amount: float
-    balance: float
+    subtotal: Decimal
+    discount: Decimal | None = Decimal("0")
+    delivery_fee: Decimal | None = Decimal("0")
+    return_delivery_fee: Decimal | None = Decimal("0")
+    penalty_fee: Decimal | None = Decimal("0")
+    total: Decimal
+    paid_amount: Decimal
+    balance: Decimal
     customer: Optional[CustomerOut] = None
     items: List[OrderItemOut] = Field(default_factory=list)
     payments: List[PaymentOut] = Field(default_factory=list)


### PR DESCRIPTION
## Summary
- standardize monetary fields on Decimal across models and schemas
- centralize financial recomputation and reuse helper
- push outstanding report aggregation to SQL with pagination

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a899b75cf8832e826fdcf7db9574d9