### PR TITLE
Fix indentation error in parse router

### DIFF
--- a/backend/app/routers/parse.py
+++ b/backend/app/routers/parse.py
@@ -165,7 +165,7 @@ def parse_message(body: ParseIn, db: Session = Depends(get_session)):
     parsed = _post_normalize(parsed, raw)
 
 
-   o = parsed.get("order", {}) or {}
+    o = parsed.get("order", {}) or {}
     sub, disc, df, rdf, pf, tot, paid = _apply_charges_and_totals(
         o.get("items") or [], o.get("charges") or {}, o.get("totals") or {}
     )


### PR DESCRIPTION
## Summary
- correct inconsistent indent in parse router to ensure load

## Testing
- `pip install -r backend/requirements.txt`
- `cd backend && pytest`

------
https://chatgpt.com/codex/tasks/task_b_68a89fa5ef04832ea6891b60263d0bca