### PR TITLE
Add returned_at column to orders

### DIFF
--- a/backend/alembic/versions/0003_add_returned_at_to_orders.py
+++ b/backend/alembic/versions/0003_add_returned_at_to_orders.py
@@ -1,0 +1,18 @@
+"""add returned_at column to orders"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0003_add_returned_at_to_orders"
+down_revision = "0002_add_order_idempotency"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("orders", sa.Column("returned_at", sa.DateTime(timezone=True), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("orders", "returned_at")


### PR DESCRIPTION
## Summary
- add migration for returned_at column on orders

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a8fbd50eec832e870e1592d3f4ae28