### PR TITLE
Fix outstanding report date calculations and parsed payload normalization

### DIFF
--- a/backend/app/routers/reports.py
+++ b/backend/app/routers/reports.py
@@ -38,10 +38,10 @@ def outstanding(
             .scalar_subquery()
     )
 
-    days_elapsed_expr = as_of - Order.delivery_date
+    days_elapsed_expr = func.DATE_PART("day", as_of - Order.delivery_date)
     months_elapsed_expr = cast(days_elapsed_expr / 30.0, Integer)
     months_expr = case(
-        (Plan.months != None, func.min(Plan.months, months_elapsed_expr)),
+        (Plan.months != None, func.least(Plan.months, months_elapsed_expr)),
         else_=months_elapsed_expr,
     )
 

--- a/frontend/utils/api.ts
+++ b/frontend/utils/api.ts
@@ -94,8 +94,9 @@ export function getOrder(id: number | string) {
 // Optional: tweak parsed payload before posting if your parser is loose
 function normalizeParsedForOrder(input: any) {
   if (!input) return input;
-  // many backends return { ok, parsed }; accept both shapes safely
-  const parsed = input?.parsed ? input.parsed : input;
+  // Unwrap common envelope shapes: { ok, data: { parsed } }
+  const payload = typeof input === "object" && "data" in input ? input.data : input;
+  const parsed = payload?.parsed ? payload.parsed : payload;
 
   // Allow both "code" or "sku" mixups; do NOT force if already correct
   if (parsed?.order) {


### PR DESCRIPTION
## Summary
- handle date differences in outstanding report using `DATE_PART` and `LEAST` to avoid interval cast errors
- unwrap `{ok,data}` envelope when normalizing parsed payloads for order creation

## Testing
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a8fd98669c832e88361a3b23329c0e