### PR TITLE
Use Decimal for plan monthly amount updates

### DIFF
--- a/backend/app/routers/orders.py
+++ b/backend/app/routers/orders.py
@@ -155,7 +155,9 @@ def update_order(order_id: int, body: OrderPatch, db: Session = Depends(get_sess
 
     if "plan" in data and order.plan:
         plan_patch = data["plan"]
-        for k in ["plan_type", "months", "monthly_amount", "status"]:
+        if "monthly_amount" in plan_patch:
+            order.plan.monthly_amount = Decimal(str(plan_patch["monthly_amount"]))
+        for k in ["plan_type", "months", "status"]:
             if k in plan_patch:
                 setattr(order.plan, k, plan_patch[k])
         if plan_patch.get("start_date"):

--- a/backend/tests/test_order_plan_update.py
+++ b/backend/tests/test_order_plan_update.py
@@ -1,0 +1,62 @@
+import sys
+from pathlib import Path
+from decimal import Decimal
+from unittest.mock import patch
+
+# Ensure backend package is importable
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app.models import Order, Plan
+from app.routers.orders import update_order, OrderPatch, PlanPatch
+
+
+class DummySession:
+    def __init__(self, order):
+        self._order = order
+
+    def get(self, model, ident):
+        return self._order
+
+    def commit(self):
+        pass
+
+    def refresh(self, obj):
+        pass
+
+
+def test_update_plan_monthly_amount_precision():
+    order = Order(
+        code="ORD1",
+        type="INSTALLMENT",
+        status="NEW",
+        customer_id=1,
+        subtotal=Decimal("0"),
+        discount=Decimal("0"),
+        delivery_fee=Decimal("0"),
+        return_delivery_fee=Decimal("0"),
+        penalty_fee=Decimal("0"),
+        total=Decimal("0"),
+        paid_amount=Decimal("0"),
+        balance=Decimal("0"),
+    )
+    plan = Plan(
+        order_id=1,
+        plan_type="INSTALLMENT",
+        months=12,
+        monthly_amount=Decimal("100.00"),
+        status="ACTIVE",
+    )
+    order.plan = plan
+    order.items = []
+    order.payments = []
+
+    db = DummySession(order)
+    body = OrderPatch(plan=PlanPatch(monthly_amount=123.45))
+
+    with patch("app.routers.orders.recompute_financials", lambda order: None), \
+         patch("app.routers.orders.envelope", lambda x: x), \
+         patch("app.routers.orders.OrderOut.model_validate", return_value=order):
+        update_order(1, body, db)
+
+    assert isinstance(order.plan.monthly_amount, Decimal)
+    assert order.plan.monthly_amount == Decimal("123.45")


### PR DESCRIPTION
## Summary
- ensure order plan monthly amounts are stored as `Decimal`
- add regression test for plan update precision

## Testing
- `pytest backend/tests -q`


------
https://chatgpt.com/codex/tasks/task_b_68a8ffaca374832eb5187566865d0176