### PR TITLE
feat: unwrap api responses

### DIFF
--- a/frontend/__tests__/api.test.ts
+++ b/frontend/__tests__/api.test.ts
@@ -1,0 +1,33 @@
+import { listOrders, getOrder } from '@/utils/api';
+
+// Use Vitest's vi to mock fetch
+
+describe('api request unwrapping', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('unwraps {ok,data} envelope for listOrders', async () => {
+    const items = [{ id: 1 }, { id: 2 }];
+    (global as any).fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      text: async () => JSON.stringify({ ok: true, data: items }),
+      headers: { get: () => 'application/json' },
+    });
+
+    const result = await listOrders();
+    expect(result).toEqual({ items, total: 2 });
+  });
+
+  it('unwraps {ok,data} envelope for getOrder', async () => {
+    const order = { id: 123, foo: 'bar' };
+    (global as any).fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      text: async () => JSON.stringify({ ok: true, data: order }),
+      headers: { get: () => 'application/json' },
+    });
+
+    const result = await getOrder(123);
+    expect(result).toEqual(order);
+  });
+});

--- a/frontend/utils/api.ts
+++ b/frontend/utils/api.ts
@@ -34,19 +34,23 @@ async function request<T = any>(
 
   const text = await res.text();
   const isJSON = res.headers.get("content-type")?.includes("application/json");
-  const data: any = isJSON && text ? JSON.parse(text) : text;
+  const payload: any = isJSON && text ? JSON.parse(text) : text;
+  const unwrapped =
+    payload && typeof payload === "object" && "data" in payload
+      ? (payload as any).data
+      : payload;
 
   if (!res.ok) {
     const msg =
-      (isJSON && (data?.detail || data?.message)) ||
-      (typeof data === "string" && data) ||
+      (isJSON && (unwrapped?.detail || unwrapped?.message)) ||
+      (typeof unwrapped === "string" && unwrapped) ||
       res.statusText;
     const err: any = new Error(msg || `HTTP ${res.status}`);
     err.status = res.status;
-    err.data = data;
+    err.data = unwrapped;
     throw err;
   }
-  return data as T;
+  return unwrapped as T;
 }
 
 // -------- Health


### PR DESCRIPTION
## Summary
- unwrap `{ok,data}` envelopes in API request helper
- test listOrders and getOrder with unwrapped responses

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68a902351fbc832eb2140be725c3b51a