### PR TITLE
Validate buyback discounts

### DIFF
--- a/backend/app/services/status_updates.py
+++ b/backend/app/services/status_updates.py
@@ -176,10 +176,17 @@ def apply_buyback(
     if discount:
         dtype = discount.get("type")
         dval = Decimal(str(discount.get("value", 0)))
+        if dval < 0:
+            raise ValueError("Invalid discount value")
         if dtype == "percent":
+            dval = min(max(dval, Decimal("0")), Decimal("100"))
             disc_amt = (amt * dval / Decimal("100")).quantize(Decimal("0.01"))
         elif dtype == "fixed":
+            if dval > amt:
+                raise ValueError("Discount exceeds buyback amount")
             disc_amt = dval
+        else:
+            raise ValueError("Invalid discount type")
 
     line_amt = amt - disc_amt
     order.status = "RETURNED"


### PR DESCRIPTION
## Summary
- validate buyback discount values before applying them

## Testing
- `black --check .` *(fails: would reformat many files)*
- `flake8 .` *(fails: numerous style errors)*
- `mypy .` *(fails: missing stubs and type errors)*
- `pytest --cov=app`


------
https://chatgpt.com/codex/tasks/task_b_68aa84c796a8832e8a83876c1b99cec0