### PR TITLE
feat: add optional dates for buyback

### DIFF
--- a/backend/app/services/status_updates.py
+++ b/backend/app/services/status_updates.py
@@ -160,6 +160,8 @@ def apply_buyback(
     discount: dict | None = None,
     method: str | None = None,
     reference: str | None = None,
+    payment_date: date | None = None,
+    return_date: datetime | None = None,
 ) -> Order:
     """Apply a buyback amount to an order and generate an adjustment.
 
@@ -183,6 +185,8 @@ def apply_buyback(
 
     line_amt = amt - disc_amt
     order.status = "RETURNED"
+    # timestamp the buyback event
+    order.returned_at = return_date or datetime.utcnow()
     if getattr(order, "plan", None):
         order.plan.status = "CANCELLED"
     lines = [
@@ -200,7 +204,7 @@ def apply_buyback(
     p = Payment(
         order_id=order.id,
         amount=-line_amt,
-        date=date.today(),
+        date=payment_date or date.today(),
         category="BUYBACK",
         method=method,
         reference=reference,


### PR DESCRIPTION
## Summary
- allow apply_buyback to accept optional payment and return dates
- use provided payment date for refund and timestamp returned_at

## Testing
- `black --check .` (fails: would reformat 47 files)
- `flake8 .` (fails: many style errors)
- `mypy .` (fails: missing library stubs and attribute errors)
- `pytest --cov=app`


------
https://chatgpt.com/codex/tasks/task_b_68aa8cd4fc94832eacc4a46860597d45