### PR TITLE
feat: add trip APIs and dispatcher tools

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,7 +2,18 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import ORJSONResponse
 from .core.config import settings, cors_origins_list
-from .routers import health, parse, orders, payments, export, documents, queue, reports, drivers
+from .routers import (
+    health,
+    parse,
+    orders,
+    payments,
+    export,
+    documents,
+    queue,
+    reports,
+    drivers,
+    trips,
+)
 
 app = FastAPI(title="OrderOps Fullstack v1", default_response_class=ORJSONResponse)
 
@@ -24,3 +35,4 @@ app.include_router(documents.router)
 app.include_router(queue.router)
 app.include_router(reports.router)
 app.include_router(drivers.router)
+app.include_router(trips.router)

--- a/backend/app/routers/__init__.py
+++ b/backend/app/routers/__init__.py
@@ -1,2 +1,2 @@
 from . import health, parse, orders, payments, export, documents, queue
-from . import reports, drivers
+from . import reports, drivers, trips

--- a/backend/app/routers/trips.py
+++ b/backend/app/routers/trips.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends, HTTPException, UploadFile, File
+from sqlalchemy.orm import Session
+from pydantic import BaseModel
+
+from ..auth.firebase import driver_auth
+from ..db import get_session
+from ..models import Trip, TripEvent, Order
+from ..schemas import TripOut
+from ..services.notifications import notify_trip_assignment
+from ..services.status_updates import recompute_financials
+from ..utils.responses import envelope
+
+router = APIRouter(prefix="/trips", tags=["trips"])
+
+
+@router.get("", response_model=dict)
+def list_trips(db: Session = Depends(get_session)):
+    trips = (
+        db.query(Trip)
+        .filter(Trip.status.in_(["ASSIGNED", "IN_PROGRESS"]))
+        .order_by(Trip.created_at.desc())
+        .all()
+    )
+    data = [TripOut.model_validate(t) for t in trips]
+    return envelope(data)
+
+
+@router.get("/active", response_model=dict)
+def list_active_trips(
+    driver=Depends(driver_auth),
+    db: Session = Depends(get_session),
+):
+    trips = (
+        db.query(Trip)
+        .filter(Trip.driver_id == driver.id)
+        .filter(Trip.status.in_(["ASSIGNED", "IN_PROGRESS"]))
+        .order_by(Trip.planned_at)
+        .all()
+    )
+    data = [TripOut.model_validate(t) for t in trips]
+    return envelope(data)
+
+
+class FailIn(BaseModel):
+    reason: str | None = None
+
+
+@router.post("/{trip_id}/start", response_model=dict)
+def start_trip(
+    trip_id: int,
+    driver=Depends(driver_auth),
+    db: Session = Depends(get_session),
+):
+    trip = db.get(Trip, trip_id)
+    if not trip or trip.driver_id != driver.id:
+        raise HTTPException(404, "Trip not found")
+    trip.status = "IN_PROGRESS"
+    trip.started_at = datetime.now(timezone.utc)
+    db.add(TripEvent(trip_id=trip.id, status="STARTED"))
+    db.commit()
+    return envelope({"status": trip.status})
+
+
+@router.post("/{trip_id}/deliver", response_model=dict)
+def deliver_trip(
+    trip_id: int,
+    photo: UploadFile | None = File(None),
+    driver=Depends(driver_auth),
+    db: Session = Depends(get_session),
+):
+    trip = db.get(Trip, trip_id)
+    if not trip or trip.driver_id != driver.id:
+        raise HTTPException(404, "Trip not found")
+    trip.status = "DELIVERED"
+    trip.delivered_at = datetime.now(timezone.utc)
+    if photo:
+        path = f"pod_{trip.id}_{photo.filename}"
+        with open(path, "wb") as f:
+            f.write(photo.file.read())
+        trip.pod_photo_url = path
+    db.add(TripEvent(trip_id=trip.id, status="DELIVERED"))
+    order = db.get(Order, trip.order_id)
+    if order:
+        recompute_financials(order)
+    db.commit()
+    return envelope({"status": trip.status, "pod_photo_url": trip.pod_photo_url})
+
+
+@router.post("/{trip_id}/fail", response_model=dict)
+def fail_trip(
+    trip_id: int,
+    body: FailIn,
+    driver=Depends(driver_auth),
+    db: Session = Depends(get_session),
+):
+    trip = db.get(Trip, trip_id)
+    if not trip or trip.driver_id != driver.id:
+        raise HTTPException(404, "Trip not found")
+    trip.status = "FAILED"
+    trip.failure_reason = body.reason or ""
+    db.add(TripEvent(trip_id=trip.id, status="FAILED", note=body.reason))
+    order = db.get(Order, trip.order_id)
+    if order:
+        recompute_financials(order)
+    db.commit()
+    return envelope({"status": trip.status})
+
+
+class AssignIn(BaseModel):
+    driver_id: int
+
+
+@router.post("/{trip_id}/assign", response_model=dict)
+def assign_trip(trip_id: int, body: AssignIn, db: Session = Depends(get_session)):
+    trip = db.get(Trip, trip_id)
+    if not trip:
+        raise HTTPException(404, "Trip not found")
+    trip.driver_id = body.driver_id
+    trip.status = "ASSIGNED"
+    notify_trip_assignment(db, trip)
+    db.commit()
+    return envelope({"status": trip.status})
+
+
+@router.post("/{trip_id}/notify", response_model=dict)
+def resend_notification(trip_id: int, db: Session = Depends(get_session)):
+    trip = db.get(Trip, trip_id)
+    if not trip:
+        raise HTTPException(404, "Trip not found")
+    count = notify_trip_assignment(db, trip)
+    return envelope({"sent": count})

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -130,3 +130,18 @@ class OrderOut(BaseModel):
 class DeviceRegisterIn(BaseModel):
     fcm_token: str
     platform: str
+
+
+class TripOut(BaseModel):
+    id: int
+    order_id: int
+    driver_id: int
+    status: str
+    planned_at: Optional[dt.datetime] = None
+    started_at: Optional[dt.datetime] = None
+    delivered_at: Optional[dt.datetime] = None
+    failure_reason: Optional[str] = None
+    pod_photo_url: Optional[str] = None
+
+    class Config:
+        from_attributes = True

--- a/backend/app/services/notifications.py
+++ b/backend/app/services/notifications.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from firebase_admin import messaging
+from sqlalchemy.orm import Session
+
+from ..auth.firebase import _get_app
+from ..models import DriverDevice, Trip
+
+
+def notify_trip_assignment(db: Session, trip: Trip) -> int:
+    """Send an FCM notification to all devices for the trip's driver."""
+    tokens = [
+        d.fcm_token
+        for d in db.query(DriverDevice).filter(DriverDevice.driver_id == trip.driver_id)
+    ]
+    if not tokens:
+        return 0
+    try:
+        app = _get_app()
+        message = messaging.MulticastMessage(
+            tokens=tokens,
+            data={
+                "type": "trip_assignment",
+                "trip_id": str(trip.id),
+                "order_id": str(trip.order_id),
+            },
+        )
+        resp = messaging.send_multicast(message, app=app)
+        return resp.success_count
+    except Exception:  # pragma: no cover - best effort only
+        return 0

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -20,3 +20,4 @@ jsonschema>=4.21
 json-repair>=0.2
 rapidfuzz>=3.6
 firebase-admin>=6.5.0
+python-multipart>=0.0.7

--- a/driver-app/src/components/TripItem.tsx
+++ b/driver-app/src/components/TripItem.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { View, Text, Button, Image } from 'react-native';
+import * as ImagePicker from 'expo-image-picker';
+import { Trip, useTripStore } from '../stores/tripStore';
+
+interface Props {
+  trip: Trip;
+  token: string;
+}
+
+export default function TripItem({ trip, token }: Props) {
+  const update = useTripStore((s) => s.updateStatus);
+
+  const handleStart = () => update(token, trip.id, 'start');
+
+  const handleDeliver = async () => {
+    const result = await ImagePicker.launchCameraAsync({
+      allowsEditing: false,
+      quality: 0.5,
+    });
+    if (!result.canceled) {
+      const uri = result.assets[0].uri;
+      await update(token, trip.id, 'deliver', uri);
+    }
+  };
+
+  const handleFail = () => update(token, trip.id, 'fail');
+
+  return (
+    <View style={{ padding: 12, borderBottomWidth: 1, borderColor: '#ccc' }}>
+      <Text style={{ fontWeight: 'bold' }}>Trip #{trip.id}</Text>
+      <Text>Status: {trip.status}</Text>
+      {trip.pod_photo_url && (
+        <Image
+          source={{ uri: trip.pod_photo_url }}
+          style={{ width: 100, height: 100, marginTop: 8 }}
+        />
+      )}
+      <View style={{ flexDirection: 'row', marginTop: 8 }}>
+        {trip.status === 'ASSIGNED' && (
+          <Button title="Start" onPress={handleStart} />
+        )}
+        {trip.status !== 'DELIVERED' && (
+          <View style={{ marginLeft: 8 }}>
+            <Button title="Deliver" onPress={handleDeliver} />
+          </View>
+        )}
+        {trip.status !== 'FAILED' && (
+          <View style={{ marginLeft: 8 }}>
+            <Button title="Fail" onPress={handleFail} />
+          </View>
+        )}
+      </View>
+    </View>
+  );
+}

--- a/driver-app/src/stores/tripStore.ts
+++ b/driver-app/src/stores/tripStore.ts
@@ -1,0 +1,60 @@
+import create from 'zustand';
+import Constants from 'expo-constants';
+
+const API_BASE =
+  (Constants?.expoConfig?.extra as any)?.apiBase ||
+  'https://orderops-api-v1.onrender.com';
+
+export interface Trip {
+  id: number;
+  order_id: number;
+  status: string;
+  pod_photo_url?: string | null;
+}
+
+interface TripState {
+  trips: Trip[];
+  load: (token: string) => Promise<void>;
+  updateStatus: (
+    token: string,
+    id: number,
+    action: 'start' | 'deliver' | 'fail',
+    photoUri?: string
+  ) => Promise<void>;
+}
+
+export const useTripStore = create<TripState>((set, get) => ({
+  trips: [],
+  load: async (token: string) => {
+    try {
+      const res = await fetch(`${API_BASE}/trips/active`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      const json = await res.json();
+      const data = Array.isArray(json.data) ? json.data : [];
+      set({ trips: data });
+    } catch (e) {
+      console.error('load trips failed', e);
+    }
+  },
+  updateStatus: async (token, id, action, photoUri) => {
+    try {
+      const url = `${API_BASE}/trips/${id}/${action}`;
+      const headers: any = { Authorization: `Bearer ${token}` };
+      let body: any;
+      if (photoUri) {
+        const fd = new FormData();
+        fd.append('photo', {
+          uri: photoUri,
+          name: 'pod.jpg',
+          type: 'image/jpeg',
+        } as any);
+        body = fd;
+      }
+      await fetch(url, { method: 'POST', headers, body });
+      await get().load(token);
+    } catch (e) {
+      console.error('update status failed', e);
+    }
+  },
+}));

--- a/frontend/pages/reports/dispatcher.tsx
+++ b/frontend/pages/reports/dispatcher.tsx
@@ -1,0 +1,76 @@
+import Layout from "@/components/Layout";
+import Card from "@/components/ui/Card";
+import Button from "@/components/ui/Button";
+import React from "react";
+import { listTrips, notifyTrip } from "@/utils/api";
+
+export default function DispatcherPage() {
+  const [trips, setTrips] = React.useState<any[]>([]);
+  const [loading, setLoading] = React.useState(false);
+
+  const load = React.useCallback(async () => {
+    setLoading(true);
+    try {
+      const r = await listTrips();
+      setTrips(Array.isArray(r) ? r : []);
+    } catch (e) {
+      console.error(e);
+    }
+    setLoading(false);
+  }, []);
+
+  React.useEffect(() => {
+    load();
+  }, [load]);
+
+  return (
+    <Layout>
+      <div className="container stack" style={{ maxWidth: '64rem' }}>
+        <Card>
+          <h2 style={{ marginTop: 0, marginBottom: 16 }}>Dispatcher</h2>
+          <Button variant="secondary" onClick={load} disabled={loading}>
+            {loading ? 'Refreshing...' : 'Refresh'}
+          </Button>
+          <div style={{ overflowX: 'auto', marginTop: 16 }}>
+            <table className="table">
+              <thead>
+                <tr>
+                  <th>ID</th>
+                  <th>Order</th>
+                  <th>Driver</th>
+                  <th>Status</th>
+                  <th></th>
+                </tr>
+              </thead>
+              <tbody>
+                {trips.map((t: any) => (
+                  <tr key={t.id}>
+                    <td>{t.id}</td>
+                    <td>{t.order_id}</td>
+                    <td>{t.driver_id}</td>
+                    <td>{t.status}</td>
+                    <td>
+                      <Button
+                        variant="secondary"
+                        onClick={() => notifyTrip(t.id).catch(console.error)}
+                      >
+                        Resend
+                      </Button>
+                    </td>
+                  </tr>
+                ))}
+                {trips.length === 0 && (
+                  <tr>
+                    <td colSpan={5} style={{ opacity: 0.7 }}>
+                      No data
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+        </Card>
+      </div>
+    </Layout>
+  );
+}

--- a/frontend/utils/api.ts
+++ b/frontend/utils/api.ts
@@ -202,6 +202,15 @@ export function markBuyback(
   });
 }
 
+// -------- Trips
+export function listTrips() {
+  return request<any>(`/trips`);
+}
+
+export function notifyTrip(id: number) {
+  return request<any>(`/trips/${id}/notify`, { method: 'POST' });
+}
+
 export function cancelInstallment(
   id: number,
   payload: {


### PR DESCRIPTION
## Summary
- implement trip router with listing, status updates, assignment and notification resend
- send FCM notifications to driver devices on assignment
- driver app fetches trips, updates status with photos and refreshes on FCM
- dispatcher web page monitors trips and can resend notifications

## Testing
- `pytest`
- `npm test` (driver-app, missing script)
- `npm test` (frontend)


------
https://chatgpt.com/codex/tasks/task_b_68aa90cec828832e8f6d574032b54152