### PR TITLE
fix: use Next.js Link on login page

### DIFF
--- a/frontend/pages/login.tsx
+++ b/frontend/pages/login.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import Link from 'next/link';
 import { useTranslation } from 'react-i18next';
 
 export default function LoginPage() {
@@ -52,7 +53,9 @@ export default function LoginPage() {
         </button>
 
         <p style={{ textAlign: 'center' }}>
-          <a href="/register">{t('login.register', { defaultValue: 'Create an account' })}</a>
+          <Link href="/register">
+            {t('login.register', { defaultValue: 'Create an account' })}
+          </Link>
         </p>
 
 


### PR DESCRIPTION
## Summary
- use Next.js Link for register link on login page

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68aa9a667640832e8ad8e5f903c2846a