### PR TITLE
fix: use Next.js Link on login page

### DIFF
--- a/frontend/pages/login.tsx
+++ b/frontend/pages/login.tsx
@@ -1,11 +1,5 @@
 import React from 'react';
-
 import Link from 'next/link';
-
-
-import Link from 'next/link';
-
-
 import { useTranslation } from 'react-i18next';
 
 export default function LoginPage() {
@@ -59,23 +53,12 @@ export default function LoginPage() {
         </button>
 
         <p style={{ textAlign: 'center' }}>
-
           <Link href="/register">
             {t('login.register', { defaultValue: 'Create an account' })}
           </Link>
-
-          <Link href="/register">{t('login.register', { defaultValue: 'Create an account' })}</Link>
         </p>
 
-
-        <p style={{ textAlign: 'center' }}>
-          <a href="/register">{t('login.register', { defaultValue: 'Create an account' })}</a>
-
-        </p>
-
-
-
-      </form>
+        </form>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- replace anchor with Next.js Link on login page

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68aa9b54c988832eb08611a602a9fcca