### PR TITLE
Refactor parser to use OpenAI Responses API for improved accuracy

### DIFF
--- a/backend/tests/test_parser_delivery_fee.py
+++ b/backend/tests/test_parser_delivery_fee.py
@@ -8,126 +8,116 @@ from app.services.parser import parse_whatsapp_text  # noqa: E402
 from app.routers.parse import _post_normalize  # noqa: E402
 from app.core.config import settings  # noqa: E402
 
+
 class DummyClient:
-    class Chat:
-        class Completions:
-            def create(self, **kwargs):
-                text = kwargs["messages"][-1]["content"].lower()
-                compact = text.replace(" ", "")
+    class Responses:
+        def parse(self, **kwargs):
+            text = kwargs["input"][-1]["content"].lower()
+            compact = text.replace(" ", "")
 
-                if "deliverycharge" in compact and "rm20" in compact:
-                    data = {
-                        "customer": {"name": "Ali"},
-                        "order": {
-                            "type": "OUTRIGHT",
-                            "items": [
-                                {
-                                    "name": "tilam canvas",
-                                    "qty": 1,
-                                    "unit_price": 199,
-                                    "line_total": 199,
-                                    "item_type": "OUTRIGHT",
-                                },
-                                {
-                                    "name": "Delivery Charge",
-                                    "qty": 1,
-                                    "unit_price": 20,
-                                    "line_total": 20,
-                                    "item_type": "FEE",
-                                },
-                            ],
-                            "charges": {},
-                            "totals": {},
-                        },
-                    }
-                elif "penghantarandanpasang" in compact and "rm20" in compact:
-                    data = {
-                        "customer": {"name": "Ali"},
-                        "order": {
-                            "type": "OUTRIGHT",
-                            "items": [
-                                {
-                                    "name": "tilam canvas",
-                                    "qty": 1,
-                                    "unit_price": 199,
-                                    "line_total": 199,
-                                    "item_type": "OUTRIGHT",
-                                },
-                                {
-                                    "name": "Penghantaran dan pasang",
-                                    "qty": 1,
-                                    "unit_price": 20,
-                                    "line_total": 20,
-                                    "item_type": "FEE",
-                                },
-                            ],
-                            "charges": {},
-                            "totals": {},
-                        },
-                    }
-                elif "penghantaran" in text and "rm20" in compact:
-                    data = {
-                        "customer": {"name": "Ali"},
-                        "order": {
-                            "type": "OUTRIGHT",
-                            "items": [
-                                {
-                                    "name": "tilam canvas",
-                                    "qty": 1,
-                                    "unit_price": 199,
-                                    "line_total": 199,
-                                    "item_type": "OUTRIGHT",
-                                }
-                            ],
-                            "charges": {"delivery_fee": 20},
-                            "totals": {},
-                        },
-                    }
-                elif "deliveryfoc" in compact:
-                    data = {
-                        "customer": {"name": "Ali"},
-                        "order": {
-                            "type": "OUTRIGHT",
-                            "items": [
-                                {
-                                    "name": "Auto travel steel wheelchair",
-                                    "qty": 1,
-                                    "unit_price": 2200,
-                                    "line_total": 2200,
-                                    "item_type": "OUTRIGHT",
-                                }
-                            ],
-                            "charges": {"delivery_fee": 0},
-                            "totals": {"total": 2200},
-                        },
-                    }
-                else:
-                    data = {
-                        "customer": {"name": "Ali"},
-                        "order": {"type": "OUTRIGHT", "items": [], "charges": {}, "totals": {}},
-                    }
+            if "deliverycharge" in compact and "rm20" in compact:
+                data = {
+                    "customer": {"name": "Ali"},
+                    "order": {
+                        "type": "OUTRIGHT",
+                        "items": [
+                            {
+                                "name": "tilam canvas",
+                                "qty": 1,
+                                "unit_price": 199,
+                                "line_total": 199,
+                                "item_type": "OUTRIGHT",
+                            },
+                            {
+                                "name": "Delivery Charge",
+                                "qty": 1,
+                                "unit_price": 20,
+                                "line_total": 20,
+                                "item_type": "FEE",
+                            },
+                        ],
+                        "charges": {},
+                        "totals": {},
+                    },
+                }
+            elif "penghantarandanpasang" in compact and "rm20" in compact:
+                data = {
+                    "customer": {"name": "Ali"},
+                    "order": {
+                        "type": "OUTRIGHT",
+                        "items": [
+                            {
+                                "name": "tilam canvas",
+                                "qty": 1,
+                                "unit_price": 199,
+                                "line_total": 199,
+                                "item_type": "OUTRIGHT",
+                            },
+                            {
+                                "name": "Penghantaran dan pasang",
+                                "qty": 1,
+                                "unit_price": 20,
+                                "line_total": 20,
+                                "item_type": "FEE",
+                            },
+                        ],
+                        "charges": {},
+                        "totals": {},
+                    },
+                }
+            elif "penghantaran" in text and "rm20" in compact:
+                data = {
+                    "customer": {"name": "Ali"},
+                    "order": {
+                        "type": "OUTRIGHT",
+                        "items": [
+                            {
+                                "name": "tilam canvas",
+                                "qty": 1,
+                                "unit_price": 199,
+                                "line_total": 199,
+                                "item_type": "OUTRIGHT",
+                            }
+                        ],
+                        "charges": {"delivery_fee": 20},
+                        "totals": {},
+                    },
+                }
+            elif "deliveryfoc" in compact:
+                data = {
+                    "customer": {"name": "Ali"},
+                    "order": {
+                        "type": "OUTRIGHT",
+                        "items": [
+                            {
+                                "name": "Auto travel steel wheelchair",
+                                "qty": 1,
+                                "unit_price": 2200,
+                                "line_total": 2200,
+                                "item_type": "OUTRIGHT",
+                            }
+                        ],
+                        "charges": {"delivery_fee": 0},
+                        "totals": {"total": 2200},
+                    },
+                }
+            else:
+                data = {
+                    "customer": {"name": "Ali"},
+                    "order": {"type": "OUTRIGHT", "items": [], "charges": {}, "totals": {}},
+                }
 
-                content = json.dumps(data)
+            content = json.dumps(data)
 
-                class Message:
-                    def __init__(self, content):
-                        self.content = content
+            class Resp:
+                def __init__(self, content):
+                    self.output_text = content
+                    self.output_parsed = None
 
-                class Choice:
-                    def __init__(self, content):
-                        self.message = Message(content)
-
-                class Resp:
-                    def __init__(self, content):
-                        self.choices = [Choice(content)]
-
-                return Resp(content)
-
-        def __init__(self):
-            self.completions = DummyClient.Chat.Completions()
+            return Resp(content)
 
     def __init__(self):
-        self.chat = DummyClient.Chat()
+        self.responses = DummyClient.Responses()
 
 def test_parse_item_and_delivery_fee(monkeypatch):
     monkeypatch.setattr(settings, "OPENAI_API_KEY", "test")

--- a/backend/tests/test_parser_mixed.py
+++ b/backend/tests/test_parser_mixed.py
@@ -8,70 +8,60 @@ from app.services.parser import parse_whatsapp_text  # noqa: E402
 from app.routers.parse import _post_normalize  # noqa: E402
 from app.core.config import settings  # noqa: E402
 
+
 class DummyClient:
-    class Chat:
-        class Completions:
-            def create(self, **kwargs):
-                text = kwargs["messages"][-1]["content"]
-                data = {
-                    "customer": {"name": "Ali"},
-                    "order": {
-                        "type": "MIXED",
-                        "code": "WC2009",
-                        "items": [
-                            {
-                                "name": "Beli Wheelchair",
-                                "qty": 1,
-                                "unit_price": 500,
-                                "line_total": 500,
-                                "item_type": "OUTRIGHT",
-                            },
-                            {
-                                "name": "Sewa Bed",
-                                "qty": 1,
-                                "unit_price": 200,
-                                "line_total": 200,
-                                "item_type": "RENTAL",
-                            },
-                            {
-                                "name": "Ventilator",
-                                "qty": 1,
-                                "unit_price": 1000,
-                                "line_total": 1000,
-                                "item_type": "INSTALLMENT",
-                                "monthly_amount": 1000,
-                            },
-                        ],
-                        "plan": {
-                            "plan_type": "INSTALLMENT",
-                            "months": 5,
+    class Responses:
+        def parse(self, **kwargs):
+            text = kwargs["input"][-1]["content"]
+            data = {
+                "customer": {"name": "Ali"},
+                "order": {
+                    "type": "MIXED",
+                    "code": "WC2009",
+                    "items": [
+                        {
+                            "name": "Beli Wheelchair",
+                            "qty": 1,
+                            "unit_price": 500,
+                            "line_total": 500,
+                            "item_type": "OUTRIGHT",
+                        },
+                        {
+                            "name": "Sewa Bed",
+                            "qty": 1,
+                            "unit_price": 200,
+                            "line_total": 200,
+                            "item_type": "RENTAL",
+                        },
+                        {
+                            "name": "Ventilator",
+                            "qty": 1,
+                            "unit_price": 1000,
+                            "line_total": 1000,
+                            "item_type": "INSTALLMENT",
                             "monthly_amount": 1000,
                         },
-                        "charges": {},
-                        "totals": {},
+                    ],
+                    "plan": {
+                        "plan_type": "INSTALLMENT",
+                        "months": 5,
+                        "monthly_amount": 1000,
                     },
-                }
-                content = json.dumps(data)
+                    "charges": {},
+                    "totals": {},
+                },
+            }
+            content = json.dumps(data)
 
-                class Message:
-                    def __init__(self, content):
-                        self.content = content
+            class Resp:
+                def __init__(self, content):
+                    self.output_text = content
+                    self.output_parsed = None
 
-                class Choice:
-                    def __init__(self, content):
-                        self.message = Message(content)
-
-                class Resp:
-                    def __init__(self, content):
-                        self.choices = [Choice(content)]
-
-                return Resp(content)
-
-        def __init__(self):
-            self.completions = DummyClient.Chat.Completions()
+            return Resp(content)
 
     def __init__(self):
-        self.chat = DummyClient.Chat()
+        self.responses = DummyClient.Responses()
 
 def test_parse_mixed_items(monkeypatch):
     monkeypatch.setattr(settings, "OPENAI_API_KEY", "test")


### PR DESCRIPTION
## Summary
- refactor WhatsApp parser to call OpenAI Responses API with JSON schema
- update tests to mock new API interface
- safely handle unexpected parse outputs from OpenAI

## Testing
- `pytest -q`
- `npm test --prefix frontend`
- `npm test --prefix driver-app` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68aab4f2b8ac832e960e8a5c5761d32a