### PR TITLE
Use /healthz in driver app and fix bcrypt compatibility

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -20,5 +20,7 @@ jsonschema>=4.21
 json-repair>=0.2
 rapidfuzz>=3.6
 firebase-admin>=6.5.0
-passlib[bcrypt]>=1.7
+# Ensure passlib/bcrypt versions are compatible (fixes "module 'bcrypt' has no attribute '__about__'")
+passlib[bcrypt]>=1.7.4
+bcrypt>=4.0.1
 PyJWT>=2.8

--- a/driver-app/App.tsx
+++ b/driver-app/App.tsx
@@ -19,9 +19,14 @@ export default function App() {
   const [error, setError] = useState<Status>(null);
 
   const checkHealth = useCallback(async () => {
+    async function ping(path: string) {
+      const r = await fetch(`${API_BASE}${path}`, { method: 'GET' });
+      return `${r.status} ${r.statusText}`;
+    }
     try {
-      const r = await fetch(`${API_BASE}/health`, { method: 'GET' });
-      setHealth(`${r.status} ${r.statusText}`);
+      let status = await ping('/healthz');
+      if (status.startsWith('404')) status = await ping('/health');
+      setHealth(status);
     } catch (e: any) {
       setHealth(`Network error: ${e?.message ?? String(e)}`);
     }


### PR DESCRIPTION
## Summary
- driver app pings `/healthz` with fallback to `/health`
- pin backend dependencies `passlib[bcrypt]` and `bcrypt` to compatible versions

## Testing
- `cd driver-app && npm test` *(fails: Missing script: "test")*
- `pip install -r backend/requirements.txt`


------
https://chatgpt.com/codex/tasks/task_b_68aacbbcdc38832e933f94732f28417f