### PR TITLE
feat(frontend): add admin panel for order assignments

### DIFF
--- a/frontend/__tests__/admin.test.tsx
+++ b/frontend/__tests__/admin.test.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import AdminPanel from '@/pages/admin';
+
+vi.mock('@/utils/api', () => ({
+  listOrders: vi.fn().mockResolvedValue({ items: [] }),
+  listDrivers: vi.fn().mockResolvedValue([]),
+  assignOrderToDriver: vi.fn(),
+}));
+
+describe('AdminPanel', () => {
+  it('renders form fields', async () => {
+    render(<AdminPanel />);
+    await waitFor(() => {
+      expect(screen.getByText('Order')).toBeTruthy();
+      expect(screen.getByText('Driver')).toBeTruthy();
+    });
+  });
+});

--- a/frontend/__tests__/api.test.ts
+++ b/frontend/__tests__/api.test.ts
@@ -1,4 +1,4 @@
-import { listOrders, getOrder } from '@/utils/api';
+import { listOrders, getOrder, listDrivers, assignOrderToDriver } from '@/utils/api';
 
 // Use Vitest's vi to mock fetch
 
@@ -29,5 +29,34 @@ describe('api request unwrapping', () => {
 
     const result = await getOrder(123);
     expect(result).toEqual(order);
+  });
+
+  it('lists drivers', async () => {
+    const drivers = [{ id: 'd1', name: 'Driver One' }];
+    (global as any).fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      text: async () => JSON.stringify(drivers),
+      headers: { get: () => 'application/json' },
+    });
+
+    const result = await listDrivers();
+    expect(result).toEqual(drivers);
+  });
+
+  it('posts assignment payload', async () => {
+    (global as any).fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      text: async () => JSON.stringify({}),
+      headers: { get: () => 'application/json' },
+    });
+
+    await assignOrderToDriver(1, 'd1');
+    expect((global as any).fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/orders/1/assign'),
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ driver_id: 'd1' }),
+      }),
+    );
   });
 });

--- a/frontend/pages/admin.tsx
+++ b/frontend/pages/admin.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import Card from '@/components/ui/Card';
+import Button from '@/components/ui/Button';
+import { listOrders, listDrivers, assignOrderToDriver } from '@/utils/api';
+
+export default function AdminPanel() {
+  const [orders, setOrders] = React.useState<any[]>([]);
+  const [drivers, setDrivers] = React.useState<any[]>([]);
+  const [orderId, setOrderId] = React.useState('');
+  const [driverId, setDriverId] = React.useState('');
+  const [busy, setBusy] = React.useState(false);
+  const [msg, setMsg] = React.useState('');
+  const [err, setErr] = React.useState('');
+
+  React.useEffect(() => {
+    listOrders(undefined, undefined, undefined, 50).then((res) => setOrders(res.items)).catch(() => {});
+    listDrivers().then(setDrivers).catch(() => {});
+  }, []);
+
+  async function onAssign() {
+    if (!orderId || !driverId) return;
+    setBusy(true); setErr(''); setMsg('');
+    try {
+      await assignOrderToDriver(orderId, driverId);
+      setMsg('Order assigned');
+    } catch (e: any) {
+      setErr(e?.message || 'Assignment failed');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="stack container" style={{ maxWidth: '48rem' }}>
+      <Card>
+        <div className="stack">
+          <label>
+            Order
+            <select value={orderId} onChange={(e) => setOrderId(e.target.value)}>
+              <option value="">Select order</option>
+              {orders.map((o) => (
+                <option key={o.id} value={o.id}>
+                  {o.code || `Order ${o.id}`}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label>
+            Driver
+            <select value={driverId} onChange={(e) => setDriverId(e.target.value)}>
+              <option value="">Select driver</option>
+              {drivers.map((d: any) => (
+                <option key={d.id || d.uid} value={d.id || d.uid}>
+                  {d.name || d.id || d.uid}
+                </option>
+              ))}
+            </select>
+          </label>
+          <Button onClick={onAssign} disabled={busy || !orderId || !driverId}>
+            Assign
+          </Button>
+          {err && <p style={{ color: '#ff4d4f', fontSize: '0.875rem' }}>{err}</p>}
+          {msg && <p style={{ color: '#16a34a', fontSize: '0.875rem' }}>{msg}</p>}
+        </div>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/utils/api.ts
+++ b/frontend/utils/api.ts
@@ -261,3 +261,12 @@ export function invoicePdfUrl(orderId: number) {
   const base = API_BASE;
   return `${base}/documents/invoice/${orderId}.pdf`;
 }
+
+// -------- Drivers
+export function listDrivers() {
+  return request<any[]>("/drivers");
+}
+
+export function assignOrderToDriver(orderId: number | string, driverId: string) {
+  return request(`/orders/${orderId}/assign`, { json: { driver_id: driverId } });
+}


### PR DESCRIPTION
## Summary
- add API helpers for listing drivers and assigning orders
- create basic admin panel page to allocate orders to drivers
- test driver APIs and admin panel rendering

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68aafb1ae0e4832e8fb85c2f7c1628e6