### PR TITLE
feat: add admin delivery status view

### DIFF
--- a/frontend/__tests__/admin.test.tsx
+++ b/frontend/__tests__/admin.test.tsx
@@ -12,8 +12,8 @@ describe('AdminPanel', () => {
   it('renders form fields', async () => {
     render(<AdminPanel />);
     await waitFor(() => {
-      expect(screen.getByText('Order')).toBeTruthy();
-      expect(screen.getByText('Driver')).toBeTruthy();
+      expect(screen.getByLabelText('Order')).toBeTruthy();
+      expect(screen.getByLabelText('Driver')).toBeTruthy();
     });
   });
 });

--- a/frontend/components/AppShell.tsx
+++ b/frontend/components/AppShell.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import Link from 'next/link';
 import LanguageSwitcher from './LanguageSwitcher';
 import { useTranslation } from 'react-i18next';
-import { Inbox, ClipboardList, FileDown, BarChart2, Menu } from 'lucide-react';
+import { Inbox, ClipboardList, FileDown, BarChart2, Menu, UserCog } from 'lucide-react';
 import { useRouter } from 'next/router';
 
 export default function AppShell({ children }: { children: React.ReactNode }) {
@@ -32,6 +32,7 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
     { href: '/orders', label: t('nav.orders'), Icon: ClipboardList, roles: ['ADMIN', 'CASHIER'] },
     { href: '/export', label: t('nav.export'), Icon: FileDown, roles: ['ADMIN'] },
     { href: '/reports/outstanding', label: t('nav.reports'), Icon: BarChart2, roles: ['ADMIN'] },
+    { href: '/admin', label: t('nav.admin'), Icon: UserCog, roles: ['ADMIN'] },
   ];
 
   const visible = nav.filter((n) => !n.roles || n.roles.includes(user?.role));

--- a/frontend/locales/en/common.json
+++ b/frontend/locales/en/common.json
@@ -6,7 +6,8 @@
     "reports": "Reports",
     "cashier": "Cashier",
     "adjustments": "Adjustments",
-    "menu": "Menu"
+    "menu": "Menu",
+    "admin": "Admin"
   },
   "intake": {
     "placeholder": "Paste a message here…",

--- a/frontend/locales/ms/common.json
+++ b/frontend/locales/ms/common.json
@@ -6,7 +6,8 @@
     "reports": "Laporan",
     "cashier": "Cashier",
     "adjustments": "Pelarasan",
-    "menu": "Menu"
+    "menu": "Menu",
+    "admin": "Admin"
   },
   "intake": {
     "placeholder": "Tampal mesej di sini…",

--- a/frontend/locales/zh/common.json
+++ b/frontend/locales/zh/common.json
@@ -6,7 +6,8 @@
     "reports": "Reports",
     "cashier": "收银",
     "adjustments": "调整",
-    "menu": "菜单"
+    "menu": "菜单",
+    "admin": "Admin"
   },
   "intake": {
     "placeholder": "把讯息贴在这里…",

--- a/frontend/pages/admin.tsx
+++ b/frontend/pages/admin.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import Card from '@/components/ui/Card';
 import Button from '@/components/ui/Button';
+import StatusBadge from '@/components/StatusBadge';
 import { listOrders, listDrivers, assignOrderToDriver } from '@/utils/api';
 
 export default function AdminPanel() {
@@ -11,9 +12,12 @@ export default function AdminPanel() {
   const [busy, setBusy] = React.useState(false);
   const [msg, setMsg] = React.useState('');
   const [err, setErr] = React.useState('');
+  const [tab, setTab] = React.useState<'unassigned' | 'assigned'>('unassigned');
 
   React.useEffect(() => {
-    listOrders(undefined, undefined, undefined, 50).then((res) => setOrders(res.items)).catch(() => {});
+    listOrders(undefined, undefined, undefined, 50)
+      .then((res) => setOrders(res.items))
+      .catch(() => {});
     listDrivers().then(setDrivers).catch(() => {});
   }, []);
 
@@ -23,12 +27,22 @@ export default function AdminPanel() {
     try {
       await assignOrderToDriver(orderId, driverId);
       setMsg('Order assigned');
+      setOrderId('');
+      setDriverId('');
+      try {
+        const res = await listOrders(undefined, undefined, undefined, 50);
+        setOrders(res.items);
+      } catch {}
     } catch (e: any) {
       setErr(e?.message || 'Assignment failed');
     } finally {
       setBusy(false);
     }
   }
+
+  const unassigned = orders.filter((o: any) => !(o.trip && o.trip.driver_id));
+  const assigned = orders.filter((o: any) => o.trip && o.trip.driver_id);
+  const current = tab === 'unassigned' ? unassigned : assigned;
 
   return (
     <div className="stack container" style={{ maxWidth: '48rem' }}>
@@ -63,6 +77,54 @@ export default function AdminPanel() {
           {msg && <p style={{ color: '#16a34a', fontSize: '0.875rem' }}>{msg}</p>}
         </div>
       </Card>
+
+      <div className="stack" style={{ marginTop: '1rem' }}>
+        <div style={{ display: 'flex', gap: 8 }}>
+          <button
+            className={`btn ${tab === 'unassigned' ? '' : 'secondary'}`}
+            onClick={() => setTab('unassigned')}
+          >
+            Unassigned Orders
+          </button>
+          <button
+            className={`btn ${tab === 'assigned' ? '' : 'secondary'}`}
+            onClick={() => setTab('assigned')}
+          >
+            Assigned Orders
+          </button>
+        </div>
+        <Card>
+          <table className="table">
+            <thead>
+              <tr>
+                <th>Order</th>
+                <th>Status</th>
+                {tab === 'assigned' && <th>Driver</th>}
+              </tr>
+            </thead>
+            <tbody>
+              {current.map((o: any) => (
+                <tr key={o.id}>
+                  <td>{o.code || `Order ${o.id}`}</td>
+                  <td>
+                    <StatusBadge value={(o.trip && o.trip.status) || o.status} />
+                  </td>
+                  {tab === 'assigned' && (
+                    <td>{o.trip?.driver_name || o.driver?.name || o.driver_id || '-'}</td>
+                  )}
+                </tr>
+              ))}
+              {current.length === 0 && (
+                <tr>
+                  <td colSpan={tab === 'assigned' ? 3 : 2} style={{ opacity: 0.7 }}>
+                    No orders
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </Card>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add Admin page to navigation bar
- show delivery assignment status in tabs for unassigned and assigned orders
- translate Admin label for supported locales

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68ab234bcf84832eb6954f47f68fe273