### PR TITLE
Use Firebase service account for App Distribution

### DIFF
--- a/.github/workflows/driver-android-debug.yml
+++ b/.github/workflows/driver-android-debug.yml
@@ -35,13 +35,12 @@ jobs:
       - name: Setup Android SDK
         uses: android-actions/setup-android@v3
 
-      # If you don't commit driver-app/google-services.json, you can load from a secret instead:
-      # - name: Write google-services.json from secret
-      #   run: |
-      #     mkdir -p driver-app
-      #     echo "$GOOGLE_SERVICES_JSON" > driver-app/google-services.json
-      #   env:
-      #     GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
+      - name: Write google-services.json from secret
+        run: |
+          mkdir -p driver-app
+          echo "$GOOGLE_SERVICES_JSON" > driver-app/google-services.json
+        env:
+          GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
 
       - name: Sanity check (android.package vs google-services.json)
         run: |

--- a/.github/workflows/driver-android-release.yml
+++ b/.github/workflows/driver-android-release.yml
@@ -19,13 +19,40 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Node
+      - name: Setup Node (no cache)
         uses: actions/setup-node@v4
         with:
           node-version: "20"
 
-      - name: Install EAS CLI
-        run: npm install -g eas-cli
+      - name: Setup Java (JDK 17)
+        uses: actions/setup-java@v4
+        with:
+          distribution: "temurin"
+          java-version: "17"
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Write google-services.json from secret
+        run: |
+          mkdir -p driver-app
+          echo "$GOOGLE_SERVICES_JSON" > driver-app/google-services.json
+        env:
+          GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
+
+      - name: Sanity check (android.package vs google-services.json)
+        run: |
+          node -e "const fs=require('fs');\
+          const p='driver-app/google-services.json';\
+          if(!fs.existsSync(p)){console.error('Missing '+p+' — commit it or provide GOOGLE_SERVICES_JSON secret.');process.exit(1)}\
+          const gs=JSON.parse(fs.readFileSync(p,'utf8'));\
+          const pkg=(gs.client||[]).find(c=>c.client_info&&c.client_info.android_client_info)?.client_info.android_client_info.package_name;\
+          const conf=fs.readFileSync('driver-app/app.config.ts','utf8');\
+          const m=/android:\\s*\\{[\\s\\S]*?package:\\s*\"([^\"]+)\"/m.exec(conf);\
+          if(!pkg){console.error('google-services.json: package_name not found');process.exit(1)}\
+          if(!m){console.error('app.config.ts: android.package not found');process.exit(1)}\
+          if(pkg!==m[1]){console.error('PACKAGE MISMATCH\\n  google-services.json = '+pkg+'\\n  app.config.ts        = '+m[1]);process.exit(1)}\
+          console.log('Package OK:', pkg);"
 
       - name: Install JS deps (lockfile-safe)
         working-directory: driver-app
@@ -35,17 +62,118 @@ jobs:
           fi
           npm ci
 
-      - name: Build Android AAB
+      - name: Ensure expo-splash-screen installed
         working-directory: driver-app
-        env:
-          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+        run: npx --yes expo@^51.0.0 install expo-splash-screen
+
+      - name: Check Expo CLI version
+        working-directory: driver-app
+        run: npx --yes expo@^51.0.0 --version
+
+      - name: Prebuild native Android project (CLEAN + LOG)
+        working-directory: driver-app
         run: |
-          eas build --platform android --profile production --non-interactive --wait
-          eas build:download --platform android --profile production --path app-release.aab --non-interactive
+          set -o pipefail
+          npx --yes expo@^51.0.0 prebuild --platform android --non-interactive --clean 2>&1 | tee prebuild.log
+
+      - name: Upload prebuild log (always)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: prebuild-log
+          path: driver-app/prebuild.log
+          if-no-files-found: ignore
+
+      - name: Ensure splash color exists
+        working-directory: driver-app
+        run: |
+          mkdir -p android/app/src/main/res/values
+          FILE="android/app/src/main/res/values/colors.xml"
+          if [ ! -f "$FILE" ] || ! grep -q 'splashscreen_background' "$FILE"; then
+            printf '%s\n' '<?xml version="1.0" encoding="utf-8"?>' '<resources>' '  <color name="splashscreen_background">#FFFFFF</color>' '</resources>' > "$FILE"
+            echo "Created $FILE with splashscreen_background"
+          else
+            echo "splashscreen_background already present"
+          fi
+
+      - name: Ensure Metro config exists
+        working-directory: driver-app
+        run: |
+          if [ ! -f metro.config.js ]; then
+            printf "const { getDefaultConfig } = require('expo/metro-config');\nmodule.exports = getDefaultConfig(__dirname);\n" > metro.config.js
+            echo "Created metro.config.js"
+          else
+            echo "metro.config.js already present"
+          fi
+
+      - name: Create JS bundle for Release (offline)
+        working-directory: driver-app
+        run: |
+          mkdir -p android/app/src/main/assets
+          ENTRY="index.js"; [ -f "$ENTRY" ] || ENTRY="App.tsx"
+          npx react-native bundle \
+            --platform android \
+            --dev false \
+            --config metro.config.js \
+            --entry-file "$ENTRY" \
+            --bundle-output android/app/src/main/assets/index.android.bundle \
+            --assets-dest android/app/src/main/res
+          test -f android/app/src/main/assets/index.android.bundle || (echo "::error::Bundle not created"; exit 1)
+          echo "Bundled JS from $ENTRY"
+
+      - name: Ensure google-services.json copied to android/app
+        working-directory: driver-app
+        run: |
+          if [ ! -f android/app/google-services.json ]; then
+            cp google-services.json android/app/google-services.json
+            echo "Copied google-services.json to android/app/"
+          else
+            echo "google-services.json already in android/app/"
+          fi
+
+      - name: Ensure gradlew exists
+        id: gradle_check
+        working-directory: driver-app/android
+        run: |
+          if [ -f ./gradlew ]; then
+            chmod +x ./gradlew
+            echo "found=true" >> $GITHUB_OUTPUT
+          else
+            echo "::error::gradlew missing (prebuild likely failed). Check the prebuild-log artifact."
+            echo "found=false" >> $GITHUB_OUTPUT
+            exit 1
+          fi
+
+      - name: Build release AAB
+        if: steps.gradle_check.outputs.found == 'true'
+        working-directory: driver-app/android
+        run: ./gradlew bundleRelease
 
       - name: Upload AAB artifact
+        if: steps.gradle_check.outputs.found == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: driver-app-release-aab
-          path: driver-app/app-release.aab
+          path: driver-app/android/app/build/outputs/bundle/release/app-release.aab
           if-no-files-found: error
+
+      - name: Install Firebase CLI
+        if: steps.gradle_check.outputs.found == 'true'
+        run: npm install -g firebase-tools
+
+      - name: Write Firebase service account
+        if: steps.gradle_check.outputs.found == 'true'
+        run: echo "$FIREBASE_SERVICE_ACCOUNT_JSON" > firebase-service-account.json
+        env:
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+
+      - name: Distribute to Firebase App Distribution
+        if: steps.gradle_check.outputs.found == 'true'
+        run: |
+          firebase appdistribution:distribute driver-app/android/app/build/outputs/bundle/release/app-release.aab \
+            --app "$FIREBASE_APP_ID" \
+            --groups "$FIREBASE_GROUPS"
+        env:
+          GOOGLE_APPLICATION_CREDENTIALS: ${{ github.workspace }}/firebase-service-account.json
+          FIREBASE_APP_ID: ${{ secrets.FIREBASE_APP_ID }}
+          FIREBASE_GROUPS: ${{ secrets.FIREBASE_GROUPS }}


### PR DESCRIPTION
## Summary
- authenticate Firebase App Distribution using a service account JSON secret
- write service account key to a file and point `firebase` CLI to it via `GOOGLE_APPLICATION_CREDENTIALS`

## Testing
- `cd driver-app && npm test` (fails: Missing script "test")
- `cd backend && pytest`

------
https://chatgpt.com/codex/tasks/task_b_68ab28eddf14832e8ee8b48aca1e3b95