### PR TITLE
fix: correct artifact upload path in Android release workflow

### DIFF
--- a/.github/workflows/driver-android-release.yml
+++ b/.github/workflows/driver-android-release.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           node-version: "20"
 
- 
+
       - name: Setup Java (JDK 17)
         uses: actions/setup-java@v4
         with:
@@ -64,10 +64,10 @@ jobs:
           fi
           npm ci
 
-     
+
       - name: Ensure expo-splash-screen installed
         working-directory: driver-app
-       
+
         run: npx --yes expo@^51.0.0 install expo-splash-screen
 
       - name: Check Expo CLI version
@@ -139,7 +139,7 @@ jobs:
         id: gradle_check
         working-directory: driver-app/android
         run: |
-       
+
           if [ -f ./gradlew ]; then
             chmod +x ./gradlew
             echo "found=true" >> $GITHUB_OUTPUT
@@ -158,8 +158,7 @@ jobs:
         if: steps.gradle_check.outputs.found == 'true'
         uses: actions/upload-artifact@v4
         with:
-          
-          path: driver-app/app-release.aab
+          name: app-release
           path: driver-app/android/app/build/outputs/bundle/release/app-release.aab
           if-no-files-found: error
 


### PR DESCRIPTION
## Summary
- fix AAB artifact upload path and name in driver Android release workflow

## Testing
- `yamllint .github/workflows/driver-android-release.yml` *(line-length warnings remain)*

------
https://chatgpt.com/codex/tasks/task_b_68ab2e83a190832ebcd95059842b9241