### PR TITLE
Fix assigned orders visibility in admin panel

### DIFF
--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -103,6 +103,16 @@ class PlanOut(BaseModel):
         from_attributes = True
 
 
+class TripOut(BaseModel):
+    id: int
+    driver_id: int
+    status: str
+    driver_name: str | None = None
+
+    class Config:
+        from_attributes = True
+
+
 class OrderOut(BaseModel):
     id: int
     code: str
@@ -122,6 +132,7 @@ class OrderOut(BaseModel):
     items: List[OrderItemOut] = Field(default_factory=list)
     payments: List[PaymentOut] = Field(default_factory=list)
     plan: Optional[PlanOut] = None
+    trip: Optional[TripOut] = None
 
     class Config:
         from_attributes = True


### PR DESCRIPTION
## Summary
- add TripOut schema and expose trip info on orders
- join trips and drivers when listing orders so admin page can show assigned orders

## Testing
- `pytest -q`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_b_68abfb5fcd1c832eb34d49474a1b5df6