### PR TITLE
feat: allow drivers to update order status

### DIFF
--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -158,5 +158,9 @@ class DriverOrderOut(BaseModel):
     status: str
 
 
+class DriverOrderUpdateIn(BaseModel):
+    status: str  # IN_TRANSIT|DELIVERED
+
+
 class AssignDriverIn(BaseModel):
     driver_id: int

--- a/driver-app/App.tsx
+++ b/driver-app/App.tsx
@@ -119,7 +119,13 @@ export default function App() {
       <Text style={styles.subtitle}>Assigned Orders</Text>
       {orders.length === 0 && <Text>No orders assigned.</Text>}
       {orders.map((o) => (
-        <OrderItem key={o.id} order={o} />
+        <OrderItem
+          key={o.id}
+          order={o}
+          token={idToken ?? ''}
+          apiBase={API_BASE}
+          refresh={() => fetchOrders(idToken ?? '')}
+        />
       ))}
     </ScrollView>
   );

--- a/driver-app/src/components/OrderItem.tsx
+++ b/driver-app/src/components/OrderItem.tsx
@@ -1,16 +1,39 @@
 import React from 'react';
-import { View, Text } from 'react-native';
+import { View, Text, Button } from 'react-native';
 import { Order } from '../stores/orderStore';
 
 interface Props {
   order: Order;
+  token: string;
+  apiBase: string;
+  refresh: () => void;
 }
 
-export default function OrderItem({ order }: Props) {
+export default function OrderItem({ order, token, apiBase, refresh }: Props) {
+  const update = async (status: string) => {
+    try {
+      await fetch(`${apiBase}/drivers/orders/${order.id}`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ status }),
+      });
+      refresh();
+    } catch {}
+  };
+
   return (
     <View style={{ padding: 12, borderBottomWidth: 1, borderColor: '#ccc' }}>
       <Text style={{ fontWeight: 'bold' }}>{order.description}</Text>
       <Text>Status: {order.status}</Text>
+      {order.status === 'ASSIGNED' && (
+        <Button title="Start" onPress={() => update('IN_TRANSIT')} />
+      )}
+      {order.status === 'IN_TRANSIT' && (
+        <Button title="Complete" onPress={() => update('DELIVERED')} />
+      )}
     </View>
   );
 }


### PR DESCRIPTION
## Summary
- allow drivers to mark trips in transit or delivered
- support driver order status updates from mobile app
- test driver status updates and log trip events

## Testing
- `pytest`
- `npm test` (frontend)
- `npm test` (driver-app) *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_b_68abfd2868e8832eadae5a113c43ef20