### PR TITLE
Add Firebase email auth and APK build workflow

### DIFF
--- a/.github/workflows/driver-android-release.yml
+++ b/.github/workflows/driver-android-release.yml
@@ -1,4 +1,4 @@
-name: Build Driver Android (Release)
+name: Build Driver Android (Release APK)
 
 on:
   workflow_dispatch:
@@ -149,17 +149,17 @@ jobs:
             exit 1
           fi
 
-      - name: Build release AAB
+      - name: Build release APK
         if: steps.gradle_check.outputs.found == 'true'
         working-directory: driver-app/android
-        run: ./gradlew bundleRelease
+        run: ./gradlew assembleRelease
 
-      - name: Upload AAB artifact
+      - name: Upload APK artifact
         if: steps.gradle_check.outputs.found == 'true'
         uses: actions/upload-artifact@v4
         with:
-          name: app-release
-          path: driver-app/android/app/build/outputs/bundle/release/app-release.aab
+          name: driver-app-release-apk
+          path: driver-app/android/app/build/outputs/apk/release/app-release.apk
           if-no-files-found: error
 
       - name: Install Firebase CLI
@@ -175,7 +175,7 @@ jobs:
       - name: Distribute to Firebase App Distribution
         if: steps.gradle_check.outputs.found == 'true'
         run: |
-          firebase appdistribution:distribute driver-app/android/app/build/outputs/bundle/release/app-release.aab \
+          firebase appdistribution:distribute driver-app/android/app/build/outputs/apk/release/app-release.apk \
             --app "${{ secrets.FIREBASE_ANDROID_APP_ID }}" \
             --groups "$FIREBASE_GROUPS"
         env:

--- a/driver-app/README.md
+++ b/driver-app/README.md
@@ -2,9 +2,16 @@
 
 This directory contains the React Native driver application built with Expo.
 
-## Release builds
+## Building APKs
 
-Use the GitHub Actions workflow `driver-android-release` to build a release
-Android App Bundle (AAB) via EAS. The generated AAB is uploaded as a workflow
-artifact for distribution or submission to Google Play.
+The repository includes GitHub Actions workflows that build Android packages
+and upload them as artifacts:
+
+- **driver-android-debug** – produces a debug APK for testing.
+- **driver-android-release** – produces a release-signed APK suitable for
+  distribution outside of Google Play. The workflow expects a
+  `GOOGLE_SERVICES_JSON` secret containing your Firebase configuration.
+
+Run either workflow from the Actions tab in GitHub and download the generated
+APK from the workflow artifacts section.
 


### PR DESCRIPTION
## Summary
- add email/password Firebase authentication with login screen and sign-out
- document APK build workflows for debug and release
- build release APK in GitHub Actions and distribute via Firebase App Distribution

## Testing
- `npm --prefix driver-app test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_b_68ac05bc7ea0832e81af520e9add245f