### PR TITLE
feat: refine driver login and show order details

### DIFF
--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -156,6 +156,7 @@ class DriverOrderOut(BaseModel):
     id: int
     description: str
     status: str
+    items: List[OrderItemOut] = Field(default_factory=list)
 
 
 class DriverOrderUpdateIn(BaseModel):

--- a/driver-app/App.tsx
+++ b/driver-app/App.tsx
@@ -30,6 +30,7 @@ export default function App() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [loginError, setLoginError] = useState<Status>(null);
+  const [signingIn, setSigningIn] = useState(false);
   const orders = useOrderStore((s) => s.orders);
   const setOrders = useOrderStore((s) => s.setOrders);
 
@@ -104,13 +105,17 @@ export default function App() {
   }, [fetchOrders]);
 
   const login = useCallback(async () => {
+    if (signingIn) return;
     setLoginError(null);
+    setSigningIn(true);
     try {
       await auth().signInWithEmailAndPassword(email.trim(), password);
     } catch (e: any) {
       setLoginError(e?.message ?? String(e));
+    } finally {
+      setSigningIn(false);
     }
-  }, [email, password]);
+  }, [email, password, signingIn]);
 
   useEffect(() => {
     const sub = auth().onAuthStateChanged(setUser);
@@ -147,9 +152,11 @@ export default function App() {
           secureTextEntry
           value={password}
           onChangeText={setPassword}
+          returnKeyType="done"
+          onSubmitEditing={login}
         />
         {loginError && <Text style={styles.error}>Error: {loginError}</Text>}
-        <Btn text="Sign In" onPress={login} />
+        <Btn text={signingIn ? 'Signing In…' : 'Sign In'} onPress={login} disabled={signingIn} />
       </View>
     );
   }
@@ -198,9 +205,9 @@ function Row({ label, value }: { label: string; value: string }) {
     </View>
   );
 }
-function Btn({ text, onPress }: { text: string; onPress: () => void }) {
+function Btn({ text, onPress, disabled }: { text: string; onPress: () => void; disabled?: boolean }) {
   return (
-    <Pressable onPress={onPress} style={styles.button}>
+    <Pressable onPress={onPress} disabled={disabled} style={[styles.button, disabled && { opacity: 0.5 }]}> 
       <Text style={styles.buttonText}>{text}</Text>
     </Pressable>
   );

--- a/driver-app/src/components/OrderItem.tsx
+++ b/driver-app/src/components/OrderItem.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { View, Text, Button } from 'react-native';
+import React, { useState } from 'react';
+import { View, Text, Button, Pressable } from 'react-native';
 import { Order } from '../stores/orderStore';
 
 interface Props {
@@ -10,6 +10,7 @@ interface Props {
 }
 
 export default function OrderItem({ order, token, apiBase, refresh }: Props) {
+  const [expanded, setExpanded] = useState(false);
   const update = async (status: string) => {
     try {
       await fetch(`${apiBase}/drivers/orders/${order.id}`, {
@@ -26,8 +27,16 @@ export default function OrderItem({ order, token, apiBase, refresh }: Props) {
 
   return (
     <View style={{ padding: 12, borderBottomWidth: 1, borderColor: '#ccc' }}>
-      <Text style={{ fontWeight: 'bold' }}>{order.description}</Text>
+      <Pressable onPress={() => setExpanded((e) => !e)}>
+        <Text style={{ fontWeight: 'bold' }}>{order.description}</Text>
+      </Pressable>
       <Text>Status: {order.status}</Text>
+      {expanded &&
+        order.items?.map((item) => (
+          <Text key={item.id}>
+            • {item.qty} x {item.name}
+          </Text>
+        ))}
       {order.status === 'ASSIGNED' && (
         <Button title="Start" onPress={() => update('IN_TRANSIT')} />
       )}

--- a/driver-app/src/stores/orderStore.ts
+++ b/driver-app/src/stores/orderStore.ts
@@ -1,9 +1,16 @@
 import create from 'zustand';
 
+export interface OrderItem {
+  id: number;
+  name: string;
+  qty: number;
+}
+
 export interface Order {
   id: number;
   description: string;
   status: string;
+  items?: OrderItem[];
 }
 
 interface OrderState {


### PR DESCRIPTION
## Summary
- return order item details to drivers and handle missing data
- expand driver app orders to show item details
- improve login UX with loading state and disabled button

## Testing
- `cd backend && pytest`
- `cd driver-app && npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_b_68ac11afba8c832eb3bae97ebd660173