### PR TITLE
feat: add driver management

### DIFF
--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -160,8 +160,15 @@ class DriverOrderOut(BaseModel):
 
 
 class DriverOrderUpdateIn(BaseModel):
-    status: str  # IN_TRANSIT|DELIVERED
+    status: str  # IN_TRANSIT|DELIVERED|ON_HOLD
 
 
 class AssignDriverIn(BaseModel):
     driver_id: int
+
+
+class DriverCreateIn(BaseModel):
+    email: str
+    password: str
+    name: str | None = None
+    phone: str | None = None

--- a/backend/tests/test_driver_create.py
+++ b/backend/tests/test_driver_create.py
@@ -1,0 +1,68 @@
+import sys
+from pathlib import Path
+import types
+
+from fastapi.testclient import TestClient
+
+# Ensure backend package importable
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app.main import app  # noqa: E402
+from app.db import get_session  # noqa: E402
+from app.models import Base, Driver, Role  # noqa: E402
+from app.auth.deps import get_current_user  # noqa: E402
+
+from sqlalchemy import create_engine, Integer
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+
+def _setup_db():
+    engine = create_engine(
+        "sqlite://",
+        future=True,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Driver.__table__.c.id.type = Integer()
+    Base.metadata.create_all(engine, tables=[Driver.__table__])
+    return sessionmaker(bind=engine, expire_on_commit=False)
+
+
+def test_admin_can_create_driver(monkeypatch):
+    SessionLocal = _setup_db()
+
+    def override_get_session():
+        with SessionLocal() as session:
+            yield session
+
+    app.dependency_overrides[get_session] = override_get_session
+
+    class DummyUser:
+        id = 1
+        role = Role.ADMIN
+
+    app.dependency_overrides[get_current_user] = lambda: DummyUser()
+
+    from app.routers import drivers as drv_router
+
+    def fake_create_user(*args, **kwargs):
+        return types.SimpleNamespace(uid="u123")
+
+    monkeypatch.setattr(drv_router.firebase_auth, "create_user", fake_create_user)
+    monkeypatch.setattr(drv_router, "_get_app", lambda: object())
+
+    client = TestClient(app)
+    resp = client.post(
+        "/drivers",
+        json={"email": "d1@example.com", "password": "secret123", "name": "Driver1"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["name"] == "Driver1"
+
+    with SessionLocal() as db:
+        driver = db.query(Driver).filter_by(firebase_uid="u123").one()
+        assert driver.name == "Driver1"
+
+    app.dependency_overrides.clear()

--- a/driver-app/src/components/OrderItem.tsx
+++ b/driver-app/src/components/OrderItem.tsx
@@ -38,10 +38,19 @@ export default function OrderItem({ order, token, apiBase, refresh }: Props) {
           </Text>
         ))}
       {order.status === 'ASSIGNED' && (
-        <Button title="Start" onPress={() => update('IN_TRANSIT')} />
+        <>
+          <Button title="Start" onPress={() => update('IN_TRANSIT')} />
+          <Button title="Hold" onPress={() => update('ON_HOLD')} />
+        </>
       )}
       {order.status === 'IN_TRANSIT' && (
-        <Button title="Complete" onPress={() => update('DELIVERED')} />
+        <>
+          <Button title="Complete" onPress={() => update('DELIVERED')} />
+          <Button title="Hold" onPress={() => update('ON_HOLD')} />
+        </>
+      )}
+      {order.status === 'ON_HOLD' && (
+        <Button title="Resume" onPress={() => update('IN_TRANSIT')} />
       )}
     </View>
   );

--- a/frontend/pages/admin.tsx
+++ b/frontend/pages/admin.tsx
@@ -2,17 +2,31 @@ import React from 'react';
 import Card from '@/components/ui/Card';
 import Button from '@/components/ui/Button';
 import StatusBadge from '@/components/StatusBadge';
-import { listOrders, listDrivers, assignOrderToDriver } from '@/utils/api';
+import {
+  listOrders,
+  listDrivers,
+  assignOrderToDriver,
+  createDriver,
+} from '@/utils/api';
 
 export default function AdminPanel() {
+  const [section, setSection] = React.useState<'orders' | 'drivers'>('orders');
   const [orders, setOrders] = React.useState<any[]>([]);
   const [drivers, setDrivers] = React.useState<any[]>([]);
+
   const [orderId, setOrderId] = React.useState('');
   const [driverId, setDriverId] = React.useState('');
   const [busy, setBusy] = React.useState(false);
   const [msg, setMsg] = React.useState('');
   const [err, setErr] = React.useState('');
-  const [tab, setTab] = React.useState<'unassigned' | 'assigned'>('unassigned');
+  const [orderTab, setOrderTab] = React.useState<'unassigned' | 'assigned'>('unassigned');
+
+  const [email, setEmail] = React.useState('');
+  const [password, setPassword] = React.useState('');
+  const [name, setName] = React.useState('');
+  const [drvMsg, setDrvMsg] = React.useState('');
+  const [drvErr, setDrvErr] = React.useState('');
+  const [creating, setCreating] = React.useState(false);
 
   React.useEffect(() => {
     listOrders(undefined, undefined, undefined, 50)
@@ -23,7 +37,9 @@ export default function AdminPanel() {
 
   async function onAssign() {
     if (!orderId || !driverId) return;
-    setBusy(true); setErr(''); setMsg('');
+    setBusy(true);
+    setErr('');
+    setMsg('');
     try {
       await assignOrderToDriver(orderId, driverId);
       setMsg('Order assigned');
@@ -40,91 +56,192 @@ export default function AdminPanel() {
     }
   }
 
+  async function onCreateDriver() {
+    if (!email || !password) return;
+    setCreating(true);
+    setDrvErr('');
+    setDrvMsg('');
+    try {
+      await createDriver({ email, password, name });
+      setDrvMsg('Driver created');
+      setEmail('');
+      setPassword('');
+      setName('');
+      const ds = await listDrivers();
+      setDrivers(ds);
+    } catch (e: any) {
+      setDrvErr(e?.message || 'Creation failed');
+    } finally {
+      setCreating(false);
+    }
+  }
+
   const unassigned = orders.filter((o: any) => !(o.trip && o.trip.driver_id));
   const assigned = orders.filter((o: any) => o.trip && o.trip.driver_id);
-  const current = tab === 'unassigned' ? unassigned : assigned;
+  const current = orderTab === 'unassigned' ? unassigned : assigned;
 
   return (
     <div className="stack container" style={{ maxWidth: '48rem' }}>
-      <Card>
-        <div className="stack">
-          <label>
-            Order
-            <select value={orderId} onChange={(e) => setOrderId(e.target.value)}>
-              <option value="">Select order</option>
-              {orders.map((o) => (
-                <option key={o.id} value={o.id}>
-                  {o.code || `Order ${o.id}`}
-                </option>
-              ))}
-            </select>
-          </label>
-          <label>
-            Driver
-            <select value={driverId} onChange={(e) => setDriverId(e.target.value)}>
-              <option value="">Select driver</option>
-              {drivers.map((d: any) => (
-                <option key={d.id || d.uid} value={d.id || d.uid}>
-                  {d.name || d.id || d.uid}
-                </option>
-              ))}
-            </select>
-          </label>
-          <Button onClick={onAssign} disabled={busy || !orderId || !driverId}>
-            Assign
-          </Button>
-          {err && <p style={{ color: '#ff4d4f', fontSize: '0.875rem' }}>{err}</p>}
-          {msg && <p style={{ color: '#16a34a', fontSize: '0.875rem' }}>{msg}</p>}
-        </div>
-      </Card>
-
-      <div className="stack" style={{ marginTop: '1rem' }}>
-        <div style={{ display: 'flex', gap: 8 }}>
-          <button
-            className={`btn ${tab === 'unassigned' ? '' : 'secondary'}`}
-            onClick={() => setTab('unassigned')}
-          >
-            Unassigned Orders
-          </button>
-          <button
-            className={`btn ${tab === 'assigned' ? '' : 'secondary'}`}
-            onClick={() => setTab('assigned')}
-          >
-            Assigned Orders
-          </button>
-        </div>
-        <Card>
-          <table className="table">
-            <thead>
-              <tr>
-                <th>Order</th>
-                <th>Status</th>
-                {tab === 'assigned' && <th>Driver</th>}
-              </tr>
-            </thead>
-            <tbody>
-              {current.map((o: any) => (
-                <tr key={o.id}>
-                  <td>{o.code || `Order ${o.id}`}</td>
-                  <td>
-                    <StatusBadge value={(o.trip && o.trip.status) || o.status} />
-                  </td>
-                  {tab === 'assigned' && (
-                    <td>{o.trip?.driver_name || o.driver?.name || o.driver_id || '-'}</td>
-                  )}
-                </tr>
-              ))}
-              {current.length === 0 && (
-                <tr>
-                  <td colSpan={tab === 'assigned' ? 3 : 2} style={{ opacity: 0.7 }}>
-                    No orders
-                  </td>
-                </tr>
-              )}
-            </tbody>
-          </table>
-        </Card>
+      <div style={{ display: 'flex', gap: 8 }}>
+        <button
+          className={`btn ${section === 'orders' ? '' : 'secondary'}`}
+          onClick={() => setSection('orders')}
+        >
+          Assignments
+        </button>
+        <button
+          className={`btn ${section === 'drivers' ? '' : 'secondary'}`}
+          onClick={() => setSection('drivers')}
+        >
+          Drivers
+        </button>
       </div>
+
+      {section === 'orders' && (
+        <>
+          <Card>
+            <div className="stack">
+              <label>
+                Order
+                <select value={orderId} onChange={(e) => setOrderId(e.target.value)}>
+                  <option value="">Select order</option>
+                  {orders.map((o) => (
+                    <option key={o.id} value={o.id}>
+                      {o.code || `Order ${o.id}`}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label>
+                Driver
+                <select value={driverId} onChange={(e) => setDriverId(e.target.value)}>
+                  <option value="">Select driver</option>
+                  {drivers.map((d: any) => (
+                    <option key={d.id || d.uid} value={d.id || d.uid}>
+                      {d.name || d.id || d.uid}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <Button onClick={onAssign} disabled={busy || !orderId || !driverId}>
+                Assign
+              </Button>
+              {err && <p style={{ color: '#ff4d4f', fontSize: '0.875rem' }}>{err}</p>}
+              {msg && <p style={{ color: '#16a34a', fontSize: '0.875rem' }}>{msg}</p>}
+            </div>
+          </Card>
+
+          <div className="stack" style={{ marginTop: '1rem' }}>
+            <div style={{ display: 'flex', gap: 8 }}>
+              <button
+                className={`btn ${orderTab === 'unassigned' ? '' : 'secondary'}`}
+                onClick={() => setOrderTab('unassigned')}
+              >
+                Unassigned Orders
+              </button>
+              <button
+                className={`btn ${orderTab === 'assigned' ? '' : 'secondary'}`}
+                onClick={() => setOrderTab('assigned')}
+              >
+                Assigned Orders
+              </button>
+            </div>
+            <Card>
+              <table className="table">
+                <thead>
+                  <tr>
+                    <th>Order</th>
+                    <th>Status</th>
+                    {orderTab === 'assigned' && <th>Driver</th>}
+                  </tr>
+                </thead>
+                <tbody>
+                  {current.map((o: any) => (
+                    <tr key={o.id}>
+                      <td>{o.code || `Order ${o.id}`}</td>
+                      <td>
+                        <StatusBadge value={(o.trip && o.trip.status) || o.status} />
+                      </td>
+                      {orderTab === 'assigned' && (
+                        <td>{o.trip?.driver_name || o.driver?.name || o.driver_id || '-'}</td>
+                      )}
+                    </tr>
+                  ))}
+                  {current.length === 0 && (
+                    <tr>
+                      <td colSpan={orderTab === 'assigned' ? 3 : 2} style={{ opacity: 0.7 }}>
+                        No orders
+                      </td>
+                    </tr>
+                  )}
+                </tbody>
+              </table>
+            </Card>
+          </div>
+        </>
+      )}
+
+      {section === 'drivers' && (
+        <>
+          <Card>
+            <div className="stack">
+              <label>
+                Email
+                <input
+                  type="email"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                />
+              </label>
+              <label>
+                Password
+                <input
+                  type="password"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                />
+              </label>
+              <label>
+                Name
+                <input value={name} onChange={(e) => setName(e.target.value)} />
+              </label>
+              <Button onClick={onCreateDriver} disabled={creating || !email || !password}>
+                Create
+              </Button>
+              {drvErr && <p style={{ color: '#ff4d4f', fontSize: '0.875rem' }}>{drvErr}</p>}
+              {drvMsg && <p style={{ color: '#16a34a', fontSize: '0.875rem' }}>{drvMsg}</p>}
+            </div>
+          </Card>
+
+          <div style={{ marginTop: '1rem' }}>
+            <Card>
+              <table className="table">
+                <thead>
+                  <tr>
+                    <th>Name</th>
+                    <th>ID</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {drivers.map((d: any) => (
+                    <tr key={d.id}>
+                      <td>{d.name || '-'}</td>
+                      <td>{d.id}</td>
+                    </tr>
+                  ))}
+                  {drivers.length === 0 && (
+                    <tr>
+                      <td colSpan={2} style={{ opacity: 0.7 }}>
+                        No drivers
+                      </td>
+                    </tr>
+                  )}
+                </tbody>
+              </table>
+            </Card>
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/frontend/utils/api.ts
+++ b/frontend/utils/api.ts
@@ -270,3 +270,12 @@ export function listDrivers() {
 export function assignOrderToDriver(orderId: number | string, driverId: string) {
   return request(`/orders/${orderId}/assign`, { json: { driver_id: driverId } });
 }
+
+export function createDriver(payload: {
+  email: string;
+  password: string;
+  name?: string;
+  phone?: string;
+}) {
+  return request<any>("/drivers", { json: payload });
+}


### PR DESCRIPTION
## Summary
- allow creating driver accounts from the admin panel
- expose driver creation API and support order hold status
- show current and past orders in driver app with hold/resume controls

## Testing
- `black --check .` *(fails: would reformat 54 files)*
- `flake8 .` *(fails: E401, E302, ...)*
- `mypy .` *(fails: Item "None" of "Order | None" has no attribute "plan", etc.)*
- `pytest --cov=app`
- `npm run lint`
- `npx tsc --noEmit`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68ac13888308832e85bedaf18ffe88af