### PR TITLE
feat(driver-app): organize orders by status

### DIFF
--- a/driver-app/App.tsx
+++ b/driver-app/App.tsx
@@ -37,6 +37,8 @@ export default function App() {
   const [signingIn, setSigningIn] = useState(false);
   const orders = useOrderStore((s) => s.orders);
   const setOrders = useOrderStore((s) => s.setOrders);
+  const activeOrders = orders.filter((o) => o.status !== 'DELIVERED');
+  const completedOrders = orders.filter((o) => o.status === 'DELIVERED');
 
   const checkHealth = useCallback(async () => {
     async function ping(path: string) {
@@ -208,9 +210,21 @@ export default function App() {
       )}
       <Btn text="Sign Out" onPress={() => auth().signOut()} />
       <View style={{ height: 24 }} />
-      <Text style={styles.subtitle}>Assigned Orders</Text>
-      {orders.length === 0 && <Text>No orders assigned.</Text>}
-      {orders.map((o) => (
+      <Text style={styles.subtitle}>Active Orders ({activeOrders.length})</Text>
+      {activeOrders.length === 0 && <Text>No active orders.</Text>}
+      {activeOrders.map((o) => (
+        <OrderItem
+          key={o.id}
+          order={o}
+          token={idToken ?? ''}
+          apiBase={API_BASE}
+          refresh={() => fetchOrders(idToken ?? '')}
+        />
+      ))}
+      <View style={{ height: 24 }} />
+      <Text style={styles.subtitle}>Completed Orders ({completedOrders.length})</Text>
+      {completedOrders.length === 0 && <Text>No completed orders.</Text>}
+      {completedOrders.map((o) => (
         <OrderItem
           key={o.id}
           order={o}

--- a/driver-app/src/components/OrderItem.tsx
+++ b/driver-app/src/components/OrderItem.tsx
@@ -11,6 +11,12 @@ interface Props {
 
 export default function OrderItem({ order, token, apiBase, refresh }: Props) {
   const [expanded, setExpanded] = useState(false);
+  const statusColors: Record<string, string> = {
+    ASSIGNED: '#2563eb',
+    IN_TRANSIT: '#16a34a',
+    ON_HOLD: '#dc2626',
+    DELIVERED: '#6b7280',
+  };
   const update = async (status: string) => {
     try {
       await fetch(`${apiBase}/drivers/orders/${order.id}`, {
@@ -30,7 +36,9 @@ export default function OrderItem({ order, token, apiBase, refresh }: Props) {
       <Pressable onPress={() => setExpanded((e) => !e)}>
         <Text style={{ fontWeight: 'bold' }}>{order.description}</Text>
       </Pressable>
-      <Text>Status: {order.status}</Text>
+      <Text style={{ color: statusColors[order.status] || '#000' }}>
+        Status: {order.status}
+      </Text>
       {expanded &&
         order.items?.map((item) => (
           <Text key={item.id}>


### PR DESCRIPTION
## Summary
- Group driver orders into active and completed sections
- Color-code order status labels for quick scanning

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_b_68ac24b117c8832e9780de6f48a836f4