### PR TITLE
Use plain language for payment totals

### DIFF
--- a/backend/app/routers/reports.py
+++ b/backend/app/routers/reports.py
@@ -27,7 +27,7 @@ def outstanding(
     offset: int = Query(0, ge=0),
     db: Session = Depends(get_session),
 ):
-    """Return outstanding balances for orders as of ``as_of`` date."""
+    """Return amount still owed for orders as of ``as_of`` date."""
 
     as_of = as_of or date.today()
     end_dt = datetime.combine(as_of, datetime.min.time())

--- a/backend/app/services/plan_math.py
+++ b/backend/app/services/plan_math.py
@@ -27,7 +27,7 @@ def months_elapsed(
 
 
 def calculate_plan_due(plan: Plan | None, as_of: date) -> Decimal:
-    """Return amount expected to be paid for ``plan`` as of ``as_of`` date."""
+    """Return planned payment amount for ``plan`` as of ``as_of`` date."""
     if not plan or not getattr(plan, "order", None):
         return Decimal("0.00")
 

--- a/frontend/pages/orders/[id].tsx
+++ b/frontend/pages/orders/[id].tsx
@@ -304,8 +304,8 @@ export default function OrderDetailPage(){
               <div>Paid</div><div>RM {Number(order.paid_amount||0).toFixed(2)}</div>
               <div>Balance</div><div><b>RM {Number(order.balance||0).toFixed(2)}</b></div>
               {due && (<>
-                <div>Accrued</div><div>RM {Number(due.accrued||0).toFixed(2)}</div>
-                <div>Outstanding</div><div><b>RM {Number(due.outstanding||0).toFixed(2)}</b></div>
+                <div>Should Have Paid</div><div>RM {Number(due.accrued||0).toFixed(2)}</div>
+                <div>Still Owed</div><div><b>RM {Number(due.outstanding||0).toFixed(2)}</b></div>
               </>)}
             </div>
 

--- a/frontend/pages/reports/outstanding.tsx
+++ b/frontend/pages/reports/outstanding.tsx
@@ -33,7 +33,7 @@ export default function OutstandingPage() {
     <Layout>
       <div className="container stack" style={{ maxWidth: '64rem' }}>
         <Card>
-          <h2 style={{ marginTop: 0, marginBottom: 16 }}>Outstanding</h2>
+          <h2 style={{ marginTop: 0, marginBottom: 16 }}>Still Owed</h2>
           <div
             style={{
               display: 'flex',
@@ -74,16 +74,25 @@ export default function OutstandingPage() {
             <table className="table">
               <thead>
                 <tr>
-                  {['code','customer','type','status','expected','paid','fees','balance'].map((k) => (
+                  {[
+                    { key: 'code', label: 'Code' },
+                    { key: 'customer', label: 'Customer' },
+                    { key: 'type', label: 'Type' },
+                    { key: 'status', label: 'Status' },
+                    { key: 'expected', label: 'Should Have Paid' },
+                    { key: 'paid', label: 'Paid' },
+                    { key: 'fees', label: 'Fees' },
+                    { key: 'balance', label: 'Still Owed' },
+                  ].map(({ key, label }) => (
                     <th
-                      key={k}
+                      key={key}
                       onClick={() =>
-                        setSort((s) => ({ key: k, asc: s.key === k ? !s.asc : true }))
+                        setSort((s) => ({ key, asc: s.key === key ? !s.asc : true }))
                       }
                       style={{ cursor: 'pointer' }}
                     >
-                      {k.charAt(0).toUpperCase() + k.slice(1)}
-                      {sort.key === k ? (sort.asc ? ' ▲' : ' ▼') : ''}
+                      {label}
+                      {sort.key === key ? (sort.asc ? ' ▲' : ' ▼') : ''}
                     </th>
                   ))}
                 </tr>
@@ -136,7 +145,7 @@ export default function OutstandingPage() {
             <Button
               variant="secondary"
               onClick={() => {
-                const header = ['Code','Customer','Type','Status','Expected','Paid','Fees','Balance'];
+                const header = ['Code','Customer','Type','Status','Should Have Paid','Paid','Fees','Still Owed'];
                 const csv = [header.join(',')]
                   .concat(
                     rows.map((r:any)=>([
@@ -154,7 +163,7 @@ export default function OutstandingPage() {
                 const url = URL.createObjectURL(blob);
                 const a = document.createElement('a');
                 a.href = url;
-                a.download = `outstanding_${asOf}.csv`;
+                a.download = `still_owed_${asOf}.csv`;
                 a.click();
                 URL.revokeObjectURL(url);
               }}


### PR DESCRIPTION
## Summary
- replace "Accrued/Outstanding" with "Should Have Paid" and "Still Owed" on order and report pages
- clarify docstrings for reports and plan math calculations
- export outstanding report as `still_owed` for clarity

## Testing
- `black --check .` *(fails: would reformat multiple files)*
- `flake8 .` *(fails: many style errors)*
- `mypy .` *(interrupted: no output)*
- `pytest --cov=app`
- `npm ci`
- `npm run lint`
- `npx tsc --noEmit`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68ac5cf75c38832eb29789b514d045d2