### PR TITLE
feat: refine layout spacing with card utilities

### DIFF
--- a/frontend/components/Card.tsx
+++ b/frontend/components/Card.tsx
@@ -1,6 +1,14 @@
 import React from 'react';
 import clsx from 'clsx';
 
-export default function Card({ children, className }: { children: React.ReactNode; className?: string }) {
-  return <div className={clsx('card', className)}>{children}</div>;
+type Props = React.HTMLAttributes<HTMLDivElement> & {
+  children: React.ReactNode;
+};
+
+export default function Card({ children, className, ...rest }: Props) {
+  return (
+    <div className={clsx('card', className)} {...rest}>
+      {children}
+    </div>
+  );
 }

--- a/frontend/pages/cashier.tsx
+++ b/frontend/pages/cashier.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import Link from "next/link";
+import Card from "@/components/Card";
 import {
   listOrders,
   orderDue,
@@ -127,9 +128,10 @@ export default function CashierPage() {
   };
 
   return (
-      <div style={{ display: "flex", gap: 16 }}>
-        <div className="card" style={{ flex: 1 }}>
-          <h2 style={{ marginTop: 0 }}>Find Order</h2>
+    <div className="stack">
+      <div className="grid" style={{ gridTemplateColumns: "1fr 1fr 260px" }}>
+        <Card className="stack" style={{ flex: 1 }}>
+          <h2>Find Order</h2>
           <input
             className="input"
             placeholder="Search order..."
@@ -152,17 +154,17 @@ export default function CashierPage() {
             </ul>
           )}
           {order && (
-            <div style={{ marginTop: 16 }}>
+            <div className="stack">
               <div>
                 <b>{order.code || order.id}</b> - {order.customer_name}
               </div>
               <div>Outstanding: RM {Number(due?.balance || 0).toFixed(2)}</div>
             </div>
           )}
-        </div>
+        </Card>
 
-        <div className="card" style={{ flex: 1 }}>
-          <h2 style={{ marginTop: 0 }}>Payment</h2>
+        <Card className="stack" style={{ flex: 1 }}>
+          <h2>Payment</h2>
           {order ? (
             <form className="stack" onSubmit={submit}>
               <input
@@ -191,7 +193,7 @@ export default function CashierPage() {
                 value={category}
                 onChange={(e) => setCategory(e.target.value)}
               />
-              <div style={{ display: "flex", gap: 8 }}>
+              <div className="cluster">
                 <input
                   className="input"
                   type="date"
@@ -215,14 +217,12 @@ export default function CashierPage() {
           ) : (
             <div>Select an order to record payment.</div>
           )}
-          <div style={{ marginTop: 8, color: err ? "#ffb3b3" : "#9fffba" }}>
-            {err || msg}
-          </div>
-        </div>
+          <div style={{ color: err ? "#ffb3b3" : "#9fffba" }}>{err || msg}</div>
+        </Card>
 
-        <div className="card" style={{ width: 260 }}>
-          <h3 style={{ marginTop: 0 }}>Export</h3>
-          <div className="stack" style={{ gap: 8 }}>
+        <Card className="stack" style={{ width: 260 }}>
+          <h3>Export</h3>
+          <div className="stack">
             <input
               className="input"
               type="date"
@@ -235,7 +235,7 @@ export default function CashierPage() {
               value={end}
               onChange={(e) => setEnd(e.target.value)}
             />
-            <label style={{ display: "flex", alignItems: "center", gap: 4 }}>
+            <label className="cluster">
               <input
                 type="checkbox"
                 checked={mark}
@@ -259,8 +259,9 @@ export default function CashierPage() {
               View Export Runs
             </Link>
           </div>
-        </div>
+        </Card>
       </div>
+    </div>
   );
 }
 

--- a/frontend/pages/export.tsx
+++ b/frontend/pages/export.tsx
@@ -19,55 +19,55 @@ export default function ExportPage() {
   }
 
   return (
-      <div className="small-container stack">
-        <Card>
-          <h2 style={{ marginTop: 0, marginBottom: 16 }}>Export Payments</h2>
-          <div className="stack" style={{ gap: 8 }}>
-            <div>
-              <label style={{ display: 'block', marginBottom: 4 }}>Start Date</label>
-              <input
-                className="input"
-                type="date"
-                value={start}
-                onChange={(e) => setStart(e.target.value)}
-              />
-            </div>
-            <div>
-              <label style={{ display: 'block', marginBottom: 4 }}>End Date</label>
-              <input
-                className="input"
-                type="date"
-                value={end}
-                onChange={(e) => setEnd(e.target.value)}
-              />
-            </div>
-            <label style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-              <input
-                type="checkbox"
-                checked={mark}
-                onChange={(e) => setMark(e.target.checked)}
-              />
-              Mark as exported
-            </label>
-            <div style={{ fontSize: '0.9em', opacity: 0.8 }}>
-              Preview shows all payments; marking excludes already exported
-              payments in future runs.
-            </div>
-            <div style={{ display: 'flex', gap: 8, paddingTop: 8 }}>
-              <Button onClick={() => download('cash')} disabled={!start || !end}>
-                Cash Export
-              </Button>
-              <Button
-                variant="secondary"
-                onClick={() => download('payments_received')}
-                disabled={!start || !end}
-              >
-                Payments Received
-              </Button>
-            </div>
+    <div className="small-container stack">
+      <Card className="stack">
+        <h2>Export Payments</h2>
+        <div className="stack">
+          <label className="stack">
+            <span>Start Date</span>
+            <input
+              className="input"
+              type="date"
+              value={start}
+              onChange={(e) => setStart(e.target.value)}
+            />
+          </label>
+          <label className="stack">
+            <span>End Date</span>
+            <input
+              className="input"
+              type="date"
+              value={end}
+              onChange={(e) => setEnd(e.target.value)}
+            />
+          </label>
+          <label className="cluster">
+            <input
+              type="checkbox"
+              checked={mark}
+              onChange={(e) => setMark(e.target.checked)}
+            />
+            Mark as exported
+          </label>
+          <div style={{ fontSize: '0.9em', opacity: 0.8 }}>
+            Preview shows all payments; marking excludes already exported
+            payments in future runs.
           </div>
-        </Card>
-      </div>
+          <div className="cluster">
+            <Button onClick={() => download('cash')} disabled={!start || !end}>
+              Cash Export
+            </Button>
+            <Button
+              variant="secondary"
+              onClick={() => download('payments_received')}
+              disabled={!start || !end}
+            >
+              Payments Received
+            </Button>
+          </div>
+        </div>
+      </Card>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary
- allow Card to accept standard div props
- rework cashier page with grid layout and stack/cluster utilities
- simplify export page spacing using stack and cluster helpers

## Testing
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_b_68ac6fcbdb10832ea4c41ac1d26a6bbe