### PR TITLE
Require authentication for protected frontend routes

### DIFF
--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -3,18 +3,35 @@ import { Inter } from 'next/font/google';
 import '@/styles/globals.css';
 import '@/i18n';
 import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
 import Layout from '@/components/Layout';
+import { getMe } from '@/utils/api';
 
 const inter = Inter({ subsets: ['latin'] });
 
 export default function App({ Component, pageProps }: AppProps) {
   const router = useRouter();
-  const noLayout = ['/login', '/register'];
+  const publicRoutes = ['/login', '/register'];
+  const [checking, setChecking] = useState(true);
+
+  useEffect(() => {
+    if (publicRoutes.includes(router.pathname)) {
+      setChecking(false);
+      return;
+    }
+    getMe()
+      .then(() => setChecking(false))
+      .catch(() => {
+        router.replace('/login');
+      });
+  }, [router.pathname, router]);
+
+  if (checking) return null;
 
   const content = <Component {...pageProps} />;
   return (
     <div className={inter.className}>
-      {noLayout.includes(router.pathname) ? content : <Layout>{content}</Layout>}
+      {publicRoutes.includes(router.pathname) ? content : <Layout>{content}</Layout>}
     </div>
   );
 }

--- a/frontend/utils/api.ts
+++ b/frontend/utils/api.ts
@@ -55,6 +55,11 @@ async function request<T = any>(
   return unwrapped as T;
 }
 
+// -------- Auth
+export function getMe() {
+  return request<any>('/auth/me');
+}
+
 // -------- Health
 export function ping() {
   return request<{ ok: boolean } | string>("/healthz");


### PR DESCRIPTION
## Summary
- enforce authentication on all non-public pages by verifying `/auth/me`
- add `getMe` API helper for retrieving current user session

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68ac739cd348832eaa4c7a455bf6347c