### PR TITLE
feat: enrich driver order details for driver app

### DIFF
--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -171,8 +171,24 @@ class DriverOut(BaseModel):
 
 class DriverOrderOut(BaseModel):
     id: int
-    description: str
+    description: Optional[str] = None     # keep for backward-compat (usually order.code)
     status: str
+    code: Optional[str] = None
+    delivery_date: Optional[dt.date] = None
+    notes: Optional[str] = None
+
+    # Money/totals (Decimal to keep precision)
+    subtotal: Decimal = Decimal("0")
+    discount: Decimal = Decimal("0")
+    delivery_fee: Decimal = Decimal("0")
+    return_delivery_fee: Decimal = Decimal("0")
+    penalty_fee: Decimal = Decimal("0")
+    total: Decimal = Decimal("0")
+    paid_amount: Decimal = Decimal("0")
+    balance: Decimal = Decimal("0")
+
+    # Relations
+    customer: Optional[CustomerOut] = None
     items: List[OrderItemOut] = Field(default_factory=list)
 
 

--- a/driver-app/src/components/OrderItem.tsx
+++ b/driver-app/src/components/OrderItem.tsx
@@ -1,5 +1,6 @@
+// OrderItem.tsx
 import React, { useState } from 'react';
-import { View, Text, Button, Pressable } from 'react-native';
+import { View, Text, Button, Pressable, Linking } from 'react-native';
 import { Order } from '../stores/orderStore';
 
 interface Props {
@@ -17,58 +18,76 @@ export default function OrderItem({ order, token, apiBase, refresh }: Props) {
     ON_HOLD: '#dc2626',
     DELIVERED: '#6b7280',
   };
+
   const update = async (status: string) => {
     try {
       await fetch(`${apiBase}/drivers/orders/${order.id}`, {
         method: 'PATCH',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${token}`,
-        },
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
         body: JSON.stringify({ status }),
       });
       refresh();
-    } catch {}
+    } catch (e) {
+      // swallow
+    }
   };
 
+  const title = order.code || order.description || `Order #${order.id}`;
+  const cust = order.customer || {};
+
   return (
-    <View
-      style={{
-        padding: 12,
-        borderWidth: 1,
-        borderColor: '#e5e7eb',
-        backgroundColor: '#fff',
-        borderRadius: 8,
-        marginBottom: 12,
-      }}
-    >
-      <Pressable onPress={() => setExpanded((e) => !e)}>
-        <Text style={{ fontWeight: 'bold', color: '#0f172a' }}>
-          {order.address || order.description}
-        </Text>
+    <View style={{ padding: 12, borderWidth: 1, borderColor: '#e5e7eb', backgroundColor: '#fff', borderRadius: 8, marginBottom: 12 }}>
+      <Pressable onPress={() => setExpanded(e => !e)}>
+        <Text style={{ fontWeight: 'bold', color: '#0f172a' }}>{title}</Text>
       </Pressable>
+
       {expanded && (
         <>
-          <Text
-            style={{
-              color: '#fff',
-              backgroundColor: statusColors[order.status] || '#6b7280',
-              paddingHorizontal: 8,
-              paddingVertical: 2,
-              borderRadius: 4,
-              alignSelf: 'flex-start',
-              marginVertical: 4,
-            }}
-          >
+          <Text style={{
+            color: '#fff',
+            backgroundColor: statusColors[order.status] || '#6b7280',
+            paddingHorizontal: 8, paddingVertical: 2, borderRadius: 4,
+            alignSelf: 'flex-start', marginVertical: 4,
+          }}>
             {order.status}
           </Text>
-          {order.phone && <Text>Phone: {order.phone}</Text>}
-          {order.total !== undefined && <Text>Total: {order.total}</Text>}
-          {order.items?.map((item) => (
-            <Text key={item.id}>
-              • {item.qty} x {item.name}
+
+          {!!cust.name && <Text>Customer: {cust.name}</Text>}
+          {!!cust.phone && (
+            <Text onPress={() => Linking.openURL(`tel:${cust.phone}`)} style={{ textDecorationLine: 'underline' }}>
+              Phone: {cust.phone} (Tap to call)
             </Text>
-          ))}
+          )}
+          {!!cust.address && <Text>Address: {cust.address}</Text>}
+          {!!cust.map_url && (
+            <Text onPress={() => Linking.openURL(String(cust.map_url))} style={{ textDecorationLine: 'underline' }}>
+              Open Map
+            </Text>
+          )}
+
+          {!!order.delivery_date && <Text>Delivery: {String(order.delivery_date).slice(0, 10)}</Text>}
+          {!!order.notes && <Text>Notes: {order.notes}</Text>}
+
+          {order.items?.length ? (
+            <>
+              <Text style={{ marginTop: 6, fontWeight: '600' }}>Items</Text>
+              {order.items.map(it => (
+                <Text key={it.id}>• {it.qty} x {it.name}{typeof it.line_total !== 'undefined' ? ` — RM ${Number(it.line_total).toFixed(2)}` : ''}</Text>
+              ))}
+            </>
+          ) : null}
+
+          <View style={{ marginTop: 6 }}>
+            {!!order.subtotal && <Text>Subtotal: RM {Number(order.subtotal).toFixed(2)}</Text>}
+            {!!order.delivery_fee && <Text>Delivery Fee: RM {Number(order.delivery_fee).toFixed(2)}</Text>}
+            {!!order.return_delivery_fee && <Text>Return Delivery: RM {Number(order.return_delivery_fee).toFixed(2)}</Text>}
+            {!!order.penalty_fee && <Text>Penalty: RM {Number(order.penalty_fee).toFixed(2)}</Text>}
+            {!!order.discount && <Text>Discount: RM {Number(order.discount).toFixed(2)}</Text>}
+            {!!order.total && <Text>Total: RM {Number(order.total).toFixed(2)}</Text>}
+            {!!order.paid_amount && <Text>Paid: RM {Number(order.paid_amount).toFixed(2)}</Text>}
+            {!!order.balance && <Text>Balance: RM {Number(order.balance).toFixed(2)}</Text>}
+          </View>
+
           {order.status === 'ASSIGNED' && (
             <>
               <Button title="Start" onPress={() => update('IN_TRANSIT')} />
@@ -81,11 +100,10 @@ export default function OrderItem({ order, token, apiBase, refresh }: Props) {
               <Button title="Hold" onPress={() => update('ON_HOLD')} />
             </>
           )}
-          {order.status === 'ON_HOLD' && (
-            <Button title="Resume" onPress={() => update('IN_TRANSIT')} />
-          )}
+          {order.status === 'ON_HOLD' && <Button title="Resume" onPress={() => update('IN_TRANSIT')} />}
         </>
       )}
     </View>
   );
 }
+

--- a/driver-app/src/stores/orderStore.ts
+++ b/driver-app/src/stores/orderStore.ts
@@ -1,19 +1,42 @@
 import create from 'zustand';
 
+export interface Customer {
+  id?: number;
+  name?: string;
+  phone?: string;
+  address?: string;
+  map_url?: string;
+}
+
 export interface OrderItem {
   id: number;
   name: string;
   qty: number;
+  unit_price?: number;
+  line_total?: number;
+  item_type?: string;
 }
 
 export interface Order {
   id: number;
-  description: string;
+  description?: string;    // compat
+  code?: string;           // new explicit order code
   status: string;
-  items?: OrderItem[];
-  address?: string;
-  phone?: string;
+
+  delivery_date?: string;
+  notes?: string;
+  customer?: Customer;
+
+  subtotal?: number;
+  discount?: number;
+  delivery_fee?: number;
+  return_delivery_fee?: number;
+  penalty_fee?: number;
   total?: number;
+  paid_amount?: number;
+  balance?: number;
+
+  items?: OrderItem[];
 }
 
 interface OrderState {


### PR DESCRIPTION
## Summary
- expand DriverOrderOut schema with customer info, item details, and monetary totals
- enrich driver order APIs with detailed payloads and new order detail route
- extend driver app store types and replace order component with richer card

## Testing
- `pytest -q`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_b_68ac99abc794832e8b56a4422ff134bd