### PR TITLE
feat: improve driver push handling

### DIFF
--- a/backend/app/routers/orders.py
+++ b/backend/app/routers/orders.py
@@ -32,6 +32,7 @@ from ..services.status_updates import (
 )
 from ..utils.responses import envelope
 from ..utils.normalize import to_decimal
+from .drivers import notify_assignment
 
 router = APIRouter(
     prefix="/orders",
@@ -325,6 +326,8 @@ def assign_order(
     db.commit()
     db.refresh(trip)
     log_action(db, current_user, "order.assign_driver", f"order_id={order.id},driver_id={driver.id}")
+    tokens = [d.fcm_token for d in driver.devices]
+    notify_assignment(tokens, order.id)
     return envelope({"order_id": order.id, "driver_id": driver.id, "trip_id": trip.id})
 
 

--- a/driver-app/README.md
+++ b/driver-app/README.md
@@ -15,3 +15,22 @@ and upload them as artifacts:
 Run either workflow from the Actions tab in GitHub and download the generated
 APK from the workflow artifacts section.
 
+## QA Checklist
+
+Before testing builds, verify the following on the Android test device:
+
+- Notifications are allowed for the app (Android 13+ requires explicit permission).
+- Battery optimizations are disabled so background handlers can run.
+- The Firebase SHA-1/256 keys are registered and a matching `google-services.json`
+  with the same `package_name` is bundled with the app.
+
+Test scenarios:
+
+1. **App killed** – assign an order; a system notification appears within a few
+   seconds. Tapping it opens the app with the orders list refreshed.
+2. **Missed push while active** – block FCM or disable network; while the app is
+   in the foreground, orders refresh within five minutes via polling.
+
+Reinstalling or updating the app should continue to receive push notifications
+thanks to automatic token refresh and re-registration.
+

--- a/driver-app/app.config.ts
+++ b/driver-app/app.config.ts
@@ -21,6 +21,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     ["expo-splash-screen", { backgroundColor: "#FFFFFF", resizeMode: "contain" }],
     "@react-native-firebase/app",
     "@react-native-firebase/messaging",
+    "@notifee/react-native",
   ],
 
   // optional mirror (plugin reads it too)

--- a/driver-app/app.config.ts
+++ b/driver-app/app.config.ts
@@ -21,7 +21,6 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     ["expo-splash-screen", { backgroundColor: "#FFFFFF", resizeMode: "contain" }],
     "@react-native-firebase/app",
     "@react-native-firebase/messaging",
-    "@notifee/react-native",
   ],
 
   // optional mirror (plugin reads it too)

--- a/driver-app/index.js
+++ b/driver-app/index.js
@@ -1,11 +1,34 @@
 import { registerRootComponent } from 'expo';
 import App from './App';
 import messaging from '@react-native-firebase/messaging';
+import notifee from '@notifee/react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 
 // background handler (required for notifications when app is quit)
 messaging().setBackgroundMessageHandler(async (msg) => {
-  if (msg?.data?.type === 'order_assigned') {
-    console.log('Order assigned while app in background');
+  const t = msg?.data?.type;
+  if (t === 'order_assigned' || t === 'trip_assignment') {
+    // 1) show a system notification
+    await notifee.displayNotification({
+      title: 'New order assigned',
+      body: 'Tap to open and view.',
+      android: { channelId: 'orders' },
+    });
+    // 2) OPTIONAL: headless fetch to stash new orders for instant UI
+    try {
+      const idt = await AsyncStorage.getItem('idToken');
+      const apiBase = 'https://orderops-api-v1.onrender.com';
+      if (idt) {
+        const r = await fetch(`${apiBase}/drivers/orders`, {
+          method: 'GET',
+          headers: { Authorization: `Bearer ${idt}` },
+        });
+        if (r.ok) {
+          const data = await r.json();
+          await AsyncStorage.setItem('pendingOrders', JSON.stringify(data?.data ?? data));
+        }
+      }
+    } catch {}
   }
 });
 

--- a/driver-app/package-lock.json
+++ b/driver-app/package-lock.json
@@ -8,6 +8,8 @@
       "name": "driver-app",
       "version": "1.1.0",
       "dependencies": {
+        "@notifee/react-native": "^9.1.8",
+        "@react-native-async-storage/async-storage": "^2.2.0",
         "@react-native-firebase/app": "^21.4.0",
         "@react-native-firebase/auth": "^21.4.0",
         "@react-native-firebase/messaging": "^21.4.0",
@@ -3994,6 +3996,15 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@notifee/react-native": {
+      "version": "9.1.8",
+      "resolved": "https://registry.npmjs.org/@notifee/react-native/-/react-native-9.1.8.tgz",
+      "integrity": "sha512-Az/dueoPerJsbbjRxu8a558wKY+gONUrfoy3Hs++5OqbeMsR0dYe6P+4oN6twrLFyzAhEA1tEoZRvQTFDRmvQg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native": "*"
+      }
+    },
     "node_modules/@npmcli/fs": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-3.1.1.tgz",
@@ -4079,6 +4090,18 @@
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/@react-native-async-storage/async-storage": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-2.2.0.tgz",
+      "integrity": "sha512-gvRvjR5JAaUZF8tv2Kcq/Gbt3JHwbKFYfmb445rhOj6NUMx3qPLixmDx5pZAyb9at1bYvJ4/eTUipU5aki45xw==",
+      "license": "MIT",
+      "dependencies": {
+        "merge-options": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react-native": "^0.0.0-0 || >=0.65 <1.0"
+      }
     },
     "node_modules/@react-native-community/cli": {
       "version": "13.6.4",
@@ -9389,6 +9412,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-plain-object": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
@@ -10809,6 +10841,18 @@
       "resolved": "https://registry.npmjs.org/memory-cache/-/memory-cache-0.2.0.tgz",
       "integrity": "sha512-OcjA+jzjOYzKmKS6IQVALHLVz+rNTMPoJvCztFaZxwG14wtAW7VRZjwTQu06vKCYOxh4jVnik7ya0SXTB0W+xA==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/merge-options": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
+      "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",

--- a/driver-app/package.json
+++ b/driver-app/package.json
@@ -13,6 +13,8 @@
     "@react-native-firebase/auth": "^21.4.0",
     "@react-native-firebase/messaging": "^21.4.0",
     "@react-native-firebase/storage": "^21.4.0",
+    "@notifee/react-native": "^9.1.8",
+    "@react-native-async-storage/async-storage": "^2.2.0",
     "expo": "~51.0.0",
     "expo-image-manipulator": "^12.0.5",
     "expo-image-picker": "^15.0.5",


### PR DESCRIPTION
## Summary
- add Notifee notifications and active-only 5-minute polling to driver app
- send push notifications from backend on order assignment
- document QA steps for driver app testing

## Testing
- `npm test` *(fails: Missing script "test")*
- `black --check .` *(fails: would reformat many files)*
- `flake8 .` *(fails: multiple style violations)*
- `mypy .` *(fails: 31 errors)*
- `pytest --cov=app` *(fails: tests/test_driver_assignment.py::test_assign_order_to_driver - sqlite3.OperationalError)*

------
https://chatgpt.com/codex/tasks/task_b_68ace47b7d54832e84c67748294a860d