### PR TITLE
Shorten Alembic revision IDs and enforce length in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,9 @@ jobs:
           pip install -r requirements.txt
           pip install black flake8 mypy pytest pytest-cov
 
+      - name: Check Alembic revision lengths
+        run: python ../scripts/check_alembic_revision_lengths.py
+
       - name: Lint
         run: |
           black --check .

--- a/backend/alembic/versions/0009_add_driver_routes.py
+++ b/backend/alembic/versions/0009_add_driver_routes.py
@@ -1,7 +1,7 @@
 from alembic import op
 import sqlalchemy as sa
 
-revision = '0009_add_driver_routes_and_trip_route_id'
+revision = '0009_add_driver_routes'
 down_revision = '0008_add_user_and_audit'
 branch_labels = None
 depends_on = None

--- a/scripts/check_alembic_revision_lengths.py
+++ b/scripts/check_alembic_revision_lengths.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+import glob
+import os
+import re
+import sys
+
+MAX_LEN = 32
+BAD = []
+
+for path in glob.glob(os.path.join("backend", "alembic", "versions", "*.py")):
+    with open(path, "r", encoding="utf-8") as f:
+        content = f.read()
+    match = re.search(r"revision\s*=\s*['\"]([^'\"]+)['\"]", content)
+    if match:
+        revision = match.group(1)
+        if len(revision) > MAX_LEN:
+            BAD.append((path, revision, len(revision)))
+    else:
+        BAD.append((path, None, 0))
+
+if BAD:
+    for path, rev, length in BAD:
+        if rev is None:
+            print(f"{path}: could not find revision string", file=sys.stderr)
+        else:
+            print(
+                f"{path}: revision '{rev}' is {length} chars (max {MAX_LEN})",
+                file=sys.stderr,
+            )
+    sys.exit(1)
+print("All Alembic revision strings are <= 32 characters.")


### PR DESCRIPTION
## Summary
- shorten revision string and filename for migration 0009 to fit Alembic's 32-char version column
- add script to verify migration revision IDs stay within 32 chars and run it in CI

## Testing
- `python ../scripts/check_alembic_revision_lengths.py`
- `black --check .` *(fails: would reformat many files)*
- `flake8 .` *(fails: many style errors)*
- `mypy .` *(fails: missing stubs and typing errors)*
- `pytest --cov=app --cov-report=xml`


------
https://chatgpt.com/codex/tasks/task_b_68ad0261acd4832eba224c7ba2ace7fe