### PR TITLE
fix: replace passlib with libpass to support newer bcrypt

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -25,7 +25,7 @@ alembic upgrade head
 
 The `0008_add_user_and_audit` migration inserts an initial `admin` user with a
 bcrypt password hash. To change the password, generate a new hash with
-`passlib` and update the row:
+`libpass` (a drop-in fork of `passlib`) and update the row:
 
 ```bash
 python - <<'PY'

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -20,9 +20,9 @@ jsonschema>=4.21
 json-repair>=0.2
 rapidfuzz>=3.6
 firebase-admin>=6.5.0
-# Ensure passlib/bcrypt versions are compatible (fixes "module 'bcrypt' has no attribute '__about__'")
-passlib[bcrypt]>=1.7.4
-bcrypt>=4.0.1
+# Use libpass (drop-in fork of passlib) to support bcrypt >=4.1 on Python 3.13
+libpass>=1.9
+bcrypt>=4.2
 PyJWT>=2.8
 Pillow>=10.0
 python-multipart>=0.0.6


### PR DESCRIPTION
## Summary
- replace `passlib` with drop-in fork `libpass` and allow `bcrypt` 4.2+
- document new package for password hashing

## Testing
- `pytest` (fails: sqlite3.OperationalError: no such table: driver_devices)


------
https://chatgpt.com/codex/tasks/task_b_68ad04f845c0832e91598b551c956dc8