### PR TITLE
fix: replace passlib with libpass and allow HTTP login

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -25,7 +25,7 @@ alembic upgrade head
 
 The `0008_add_user_and_audit` migration inserts an initial `admin` user with a
 bcrypt password hash. To change the password, generate a new hash with
-`passlib` and update the row:
+`libpass` (a drop-in fork of `passlib`) and update the row:
 
 ```bash
 python - <<'PY'
@@ -42,6 +42,7 @@ production.
 ## Environment variables
 
 - `FIREBASE_SERVICE_ACCOUNT_JSON`: JSON string for Firebase service account used to verify driver ID tokens.
+- `COOKIE_SECURE`: set to `true` to send the auth cookie only over HTTPS (defaults to `false` for local development).
 
 ## Worker configuration
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -24,6 +24,7 @@ class Settings(BaseSettings):
     # Auth
     JWT_SECRET: str = "change-me"
     ACCESS_TOKEN_EXPIRE_MINUTES: int = 60
+    COOKIE_SECURE: bool = False
 
     class Config:
         env_file = ".env"

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -6,15 +6,7 @@ from sqlalchemy.orm import Session
 
 from ..db import get_session
 from ..models import User, Role, AuditLog
-
 from ..core.security import verify_password, create_access_token, hash_password
-
-
-from ..core.security import verify_password, create_access_token, hash_password
-
-from ..core.security import verify_password, create_access_token
-
-
 from ..auth.deps import get_current_user
 from ..core.config import settings
 
@@ -48,7 +40,7 @@ def login(payload: LoginIn, response: Response, db: Session = Depends(get_sessio
         "token",
         token,
         httponly=True,
-        secure=True,
+        secure=settings.COOKIE_SECURE,
         samesite="lax",
         max_age=max_age,
     )
@@ -97,7 +89,12 @@ def logout(
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_session),
 ):
-    response.delete_cookie("token")
+    response.delete_cookie(
+        "token",
+        httponly=True,
+        secure=settings.COOKIE_SECURE,
+        samesite="lax",
+    )
     db.add(AuditLog(user_id=current_user.id, action="logout"))
     db.commit()
     return {"ok": True}

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -20,9 +20,9 @@ jsonschema>=4.21
 json-repair>=0.2
 rapidfuzz>=3.6
 firebase-admin>=6.5.0
-# Ensure passlib/bcrypt versions are compatible (fixes "module 'bcrypt' has no attribute '__about__'")
-passlib[bcrypt]>=1.7.4
-bcrypt>=4.0.1
+# Use libpass (drop-in fork of passlib) to support bcrypt >=4.1 on Python 3.13
+libpass>=1.9
+bcrypt>=4.2
 PyJWT>=2.8
 Pillow>=10.0
 python-multipart>=0.0.6


### PR DESCRIPTION
## Summary
- replace `passlib` with drop-in fork `libpass` and allow `bcrypt` 4.2+
- document new package for password hashing
- make auth cookie "Secure" flag configurable and document `COOKIE_SECURE`

## Testing
- `pytest` *(fails: Form data requires "python-multipart" to be installed)*
- `npm test` *(fails: [vitest] No "listRoutes" export is defined on the "@/utils/api" mock)*

------
https://chatgpt.com/codex/tasks/task_b_68ad04f845c0832e91598b551c956dc8