### PR TITLE
Fix route date filter and secure auth cookies

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,5 +1,6 @@
 from pydantic_settings import BaseSettings
 from typing import Optional
+from pydantic import Field
 
 class Settings(BaseSettings):
     APP_VERSION: str = "local"
@@ -22,9 +23,9 @@ class Settings(BaseSettings):
     WORKER_MAX_ATTEMPTS: int = 5
 
     # Auth
-    JWT_SECRET: str = "change-me"
+    JWT_SECRET: str = Field("change-me", env="JWT_SECRET")
     ACCESS_TOKEN_EXPIRE_MINUTES: int = 60
-    COOKIE_SECURE: bool = False
+    COOKIE_SECURE: bool = True
 
     class Config:
         env_file = ".env"

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -41,7 +41,7 @@ def login(payload: LoginIn, response: Response, db: Session = Depends(get_sessio
         token,
         httponly=True,
         secure=settings.COOKIE_SECURE,
-        samesite="lax",
+        samesite="none",
         max_age=max_age,
     )
     db.add(AuditLog(user_id=user.id, action="login"))
@@ -93,7 +93,7 @@ def logout(
         "token",
         httponly=True,
         secure=settings.COOKIE_SECURE,
-        samesite="lax",
+        samesite="none",
     )
     db.add(AuditLog(user_id=current_user.id, action="logout"))
     db.commit()

--- a/backend/app/routers/routes.py
+++ b/backend/app/routers/routes.py
@@ -31,7 +31,11 @@ def create_route(payload: RouteCreateIn, db: Session = Depends(get_session)):
 def list_routes(date: str | None = None, db: Session = Depends(get_session)):
     q = db.query(DriverRoute)
     if date:
-        q = q.filter(DriverRoute.route_date == date)
+        try:
+            d = dt_date.fromisoformat(date)
+        except ValueError:
+            raise HTTPException(400, "Invalid date format")
+        q = q.filter(DriverRoute.route_date == d)
     return q.order_by(DriverRoute.route_date.desc(), DriverRoute.id.desc()).all()
 
 

--- a/backend/tests/test_driver_assignment.py
+++ b/backend/tests/test_driver_assignment.py
@@ -11,7 +11,17 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from app.main import app  # noqa: E402
 from app.db import get_session  # noqa: E402
-from app.models import Base, Driver, Customer, Order, Trip, TripEvent, DriverRoute, Role  # noqa: E402
+from app.models import (
+    Base,
+    Driver,
+    Customer,
+    Order,
+    Trip,
+    TripEvent,
+    DriverRoute,
+    Role,
+    DriverDevice,
+)  # noqa: E402
 from app.routers import orders as orders_router, routes as routes_router  # noqa: E402
 from app.auth import firebase as auth_firebase  # noqa: E402
 
@@ -29,6 +39,8 @@ def _setup_db():
     Order.__table__.c.customer_id.type = Integer()
     DriverRoute.__table__.c.id.type = Integer()
     DriverRoute.__table__.c.driver_id.type = Integer()
+    DriverDevice.__table__.c.id.type = Integer()
+    DriverDevice.__table__.c.driver_id.type = Integer()
     Trip.__table__.c.id.type = Integer()
     Trip.__table__.c.order_id.type = Integer()
     Trip.__table__.c.driver_id.type = Integer()
@@ -42,6 +54,7 @@ def _setup_db():
             Customer.__table__,
             Order.__table__,
             DriverRoute.__table__,
+            DriverDevice.__table__,
             Trip.__table__,
             TripEvent.__table__,
         ],

--- a/backend/tests/test_routes_date_filter.py
+++ b/backend/tests/test_routes_date_filter.py
@@ -1,0 +1,65 @@
+import sys
+from pathlib import Path
+from datetime import date
+
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, Integer
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app.main import app  # noqa: E402
+from app.db import get_session  # noqa: E402
+from app.models import Base, Driver, DriverRoute, Role  # noqa: E402
+from app.routers import routes as routes_router  # noqa: E402
+
+
+def _setup_db():
+    engine = create_engine(
+        "sqlite://",
+        future=True,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Driver.__table__.c.id.type = Integer()
+    DriverRoute.__table__.c.id.type = Integer()
+    DriverRoute.__table__.c.driver_id.type = Integer()
+    Base.metadata.create_all(engine, tables=[Driver.__table__, DriverRoute.__table__])
+    return sessionmaker(bind=engine, expire_on_commit=False)
+
+
+def test_route_date_filter(monkeypatch):
+    SessionLocal = _setup_db()
+
+    def override_get_session():
+        with SessionLocal() as session:
+            yield session
+
+    app.dependency_overrides[get_session] = override_get_session
+
+    class DummyUser:
+        id = 1
+        role = Role.ADMIN
+
+    dep = routes_router.router.dependencies[0].dependency
+    app.dependency_overrides[dep] = lambda: DummyUser()
+
+    client = TestClient(app)
+
+    with SessionLocal() as db:
+        driver = Driver(firebase_uid="u1", name="D1")
+        db.add(driver)
+        db.flush()
+        route1 = DriverRoute(driver_id=driver.id, route_date=date(2024, 1, 1), name="R1")
+        route2 = DriverRoute(driver_id=driver.id, route_date=date(2024, 1, 2), name="R2")
+        db.add_all([route1, route2])
+        db.commit()
+
+    resp = client.get("/routes", params={"date": "2024-01-01"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 1
+    assert data[0]["route_date"] == "2024-01-01"
+
+    app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary
- parse route date query into `date` and validate format
- set auth cookies with `SameSite=None` and secure-by-default config
- ensure test DB includes driver device table and add route filter test

## Testing
- `pip install -r backend/requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68ad082668f0832e9e328c07f17db2c7