### PR TITLE
Improve admin accessibility and usability

### DIFF
--- a/frontend/__tests__/admin-nav.test.tsx
+++ b/frontend/__tests__/admin-nav.test.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { vi } from 'vitest';
+import { RouterContext } from 'next/dist/shared/lib/router-context.shared-runtime';
+import type { NextRouter } from 'next/router';
+import AdminNav from '@/components/admin/AdminNav';
+
+function createRouter(pathname: string): NextRouter {
+  return {
+    pathname,
+    route: pathname,
+    query: {},
+    asPath: pathname,
+    basePath: '',
+    push: vi.fn(),
+    replace: vi.fn(),
+    reload: vi.fn(),
+    back: vi.fn(),
+    prefetch: vi.fn(),
+    beforePopState: vi.fn(),
+    events: { on: vi.fn(), off: vi.fn(), emit: vi.fn() },
+    isFallback: false,
+    isReady: true,
+    isPreview: false,
+    isLocaleDomain: false,
+  } as unknown as NextRouter;
+}
+
+describe('AdminNav', () => {
+  it('marks active link with aria-current', () => {
+    const router = createRouter('/admin/routes');
+    render(
+      <RouterContext.Provider value={router}>
+        <AdminNav />
+      </RouterContext.Provider>
+    );
+    expect(screen.getByRole('link', { name: /routes/i })).toHaveAttribute(
+      'aria-current',
+      'page'
+    );
+  });
+});

--- a/frontend/__tests__/assign-select-all.test.tsx
+++ b/frontend/__tests__/assign-select-all.test.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { RouterContext } from 'next/dist/shared/lib/router-context.shared-runtime';
+import type { NextRouter } from 'next/router';
+import { vi } from 'vitest';
+import AdminAssignPage from '@/pages/admin/assign';
+
+const orders = [
+  { id: '1', orderNo: '100', deliveryDate: '2024-07-01', status: 'NEW' },
+  { id: '2', orderNo: '101', deliveryDate: '2024-07-01', status: 'NEW' },
+];
+
+vi.mock('@tanstack/react-query', async () => {
+  const actual = await vi.importActual<any>('@tanstack/react-query');
+  return {
+    ...actual,
+    useQuery: () => ({ data: orders, isLoading: false, isError: false }),
+  };
+});
+
+function createRouter(): NextRouter {
+  return {
+    pathname: '/admin/assign',
+    route: '/admin/assign',
+    query: { date: '2024-07-01' },
+    asPath: '/admin/assign',
+    basePath: '',
+    push: vi.fn(),
+    replace: vi.fn(),
+    reload: vi.fn(),
+    back: vi.fn(),
+    prefetch: vi.fn(),
+    beforePopState: vi.fn(),
+    events: { on: vi.fn(), off: vi.fn(), emit: vi.fn() },
+    isFallback: false,
+    isReady: true,
+    isPreview: false,
+    isLocaleDomain: false,
+  } as unknown as NextRouter;
+}
+
+describe('Assign select all', () => {
+  it('toggles all row checkboxes', async () => {
+    const user = userEvent.setup();
+    const router = createRouter();
+    render(
+      <RouterContext.Provider value={router}>
+        <AdminAssignPage />
+      </RouterContext.Provider>
+    );
+    const selectAll = screen.getByRole('checkbox', { name: /select all/i });
+    const rowChecks = screen.getAllByRole('checkbox', { name: /select order/i });
+    await user.click(selectAll);
+    rowChecks.forEach((c) => expect(c).toBeChecked());
+    await user.click(selectAll);
+    rowChecks.forEach((c) => expect(c).not.toBeChecked());
+  });
+});

--- a/frontend/__tests__/route-card.test.tsx
+++ b/frontend/__tests__/route-card.test.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+import { RouteCard } from '@/pages/admin/routes';
+
+describe('RouteCard', () => {
+  it('calls onSelect with keyboard', async () => {
+    const route: any = { id: '1', name: 'Route A', driverId: '', stops: [] };
+    const onSelect = vi.fn();
+    render(<RouteCard route={route} onSelect={onSelect} />);
+    const card = screen.getByRole('button', { name: /route a/i });
+    card.focus();
+    const user = userEvent.setup();
+    await user.keyboard('{Enter}');
+    card.focus();
+    await user.keyboard(' ');
+    expect(onSelect).toHaveBeenCalledTimes(2);
+  });
+});

--- a/frontend/components/admin/AdminLayout.tsx
+++ b/frontend/components/admin/AdminLayout.tsx
@@ -1,11 +1,24 @@
 import React from 'react';
+import { useRouter } from 'next/router';
 import AdminNav from './AdminNav';
 
-export default function AdminLayout({ children }:{children:React.ReactNode}){
+export default function AdminLayout({ children }: { children: React.ReactNode }) {
+  const mainRef = React.useRef<HTMLElement>(null);
+  const router = useRouter();
+
+  React.useEffect(() => {
+    mainRef.current?.focus();
+  }, [router.asPath]);
+
   return (
-    <div>
-      <AdminNav />
-      <main style={{padding:16}}>{children}</main>
-    </div>
+    <>
+      <a href="#admin-main" className="sr-only not-sr-only">Skip to content</a>
+      <header>
+        <AdminNav />
+      </header>
+      <main id="admin-main" tabIndex={-1} ref={mainRef} style={{ padding: 16 }}>
+        {children}
+      </main>
+    </>
   );
 }

--- a/frontend/components/admin/AdminNav.tsx
+++ b/frontend/components/admin/AdminNav.tsx
@@ -1,11 +1,37 @@
+import React from 'react';
 import Link from 'next/link';
+import { useRouter } from 'next/router';
 
-export default function AdminNav(){
+export default function AdminNav() {
+  const { pathname } = useRouter();
+  const items = [
+    { href: '/admin/routes', label: 'Routes' },
+    { href: '/admin/assign', label: 'Assign' },
+    { href: '/admin/driver-commissions', label: 'Driver Commissions' },
+  ];
   return (
-    <nav style={{display:'flex',gap:8,padding:8,borderBottom:'1px solid #eee',background:'#fff'}}>
-      <Link className="btn secondary" href="/admin/routes">Routes</Link>
-      <Link className="btn secondary" href="/orders">Orders</Link>
-      <Link className="btn" href="/admin/driver-commissions">Driver Commissions</Link>
+    <nav
+      style={{
+        display: 'flex',
+        gap: 8,
+        padding: 8,
+        borderBottom: '1px solid #eee',
+        background: '#fff',
+        position: 'sticky',
+        top: 0,
+        zIndex: 10,
+      }}
+    >
+      {items.map((item) => (
+        <Link
+          key={item.href}
+          className="btn secondary"
+          href={item.href}
+          aria-current={pathname === item.href ? 'page' : undefined}
+        >
+          {item.label}
+        </Link>
+      ))}
     </nav>
   );
 }

--- a/frontend/components/admin/AssignToRouteModal.tsx
+++ b/frontend/components/admin/AssignToRouteModal.tsx
@@ -9,7 +9,7 @@ interface Props {
 }
 
 export default function AssignToRouteModal({ orderIds, date, onClose }: Props) {
-  const { data: routes } = useQuery({
+  const { data: routes, isLoading, isError } = useQuery({
     queryKey: ['routes', date],
     queryFn: () => fetchRoutes(date),
   });
@@ -25,18 +25,73 @@ export default function AssignToRouteModal({ orderIds, date, onClose }: Props) {
     },
   });
 
+  const dialogRef = React.useRef<HTMLDivElement>(null);
+  React.useEffect(() => {
+    const el = dialogRef.current;
+    const prev = document.activeElement as HTMLElement | null;
+    el?.focus();
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onClose();
+      }
+      if (e.key === 'Tab' && el) {
+        const focusable = Array.from(
+          el.querySelectorAll<HTMLElement>(
+            'a,button,input,select,textarea,[tabindex]:not([tabindex="-1"])'
+          )
+        );
+        if (focusable.length === 0) return;
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        if (e.shiftKey) {
+          if (document.activeElement === first) {
+            e.preventDefault();
+            last.focus();
+          }
+        } else {
+          if (document.activeElement === last) {
+            e.preventDefault();
+            first.focus();
+          }
+        }
+      }
+    };
+    el?.addEventListener('keydown', onKey);
+    return () => {
+      el?.removeEventListener('keydown', onKey);
+      prev?.focus();
+    };
+  }, [onClose]);
+
   return (
-    <div style={{ position: 'fixed', top: 0, left: 0, right: 0, bottom: 0, background: 'rgba(0,0,0,0.3)' }}>
-      <div style={{ background: '#fff', padding: 16, maxWidth: 320, margin: '10% auto' }}>
-        <h3>Assign to route</h3>
-        <select value={routeId} onChange={(e) => setRouteId(e.target.value)}>
-          <option value="">Select route</option>
-          {routes?.map((r) => (
-            <option key={r.id} value={r.id}>
-              {r.name}
-            </option>
-          ))}
-        </select>
+    <div
+      style={{ position: 'fixed', top: 0, left: 0, right: 0, bottom: 0, background: 'rgba(0,0,0,0.3)' }}
+    >
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="assign-title"
+        tabIndex={-1}
+        style={{ background: '#fff', padding: 16, maxWidth: 320, margin: '10% auto' }}
+      >
+        <h3 id="assign-title">Assign to route</h3>
+        {isLoading && <div role="status">Loading...</div>}
+        {isError && <div role="alert">Failed to load</div>}
+        {!isLoading && !isError && (
+          <label>
+            <span className="sr-only">Route</span>
+            <select value={routeId} onChange={(e) => setRouteId(e.target.value)}>
+              <option value="">Select route</option>
+              {routes?.map((r) => (
+                <option key={r.id} value={r.id}>
+                  {r.name}
+                </option>
+              ))}
+            </select>
+          </label>
+        )}
         <div style={{ marginTop: 16 }}>
           <button onClick={() => mutation.mutate()} disabled={!routeId}>
             Assign

--- a/frontend/components/admin/RouteDetailDrawer.tsx
+++ b/frontend/components/admin/RouteDetailDrawer.tsx
@@ -29,10 +29,57 @@ export default function RouteDetailDrawer({ route, onClose }: Props) {
       qc.invalidateQueries({ queryKey: ['routes', route.date] }),
   });
 
+  const dialogRef = React.useRef<HTMLDivElement>(null);
+
+  React.useEffect(() => {
+    const el = dialogRef.current;
+    const prev = document.activeElement as HTMLElement | null;
+    el?.focus();
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onClose();
+      }
+      if (e.key === 'Tab' && el) {
+        const focusable = Array.from(
+          el.querySelectorAll<HTMLElement>(
+            'a,button,input,select,textarea,[tabindex]:not([tabindex="-1"])'
+          )
+        );
+        if (focusable.length === 0) return;
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        if (e.shiftKey) {
+          if (document.activeElement === first) {
+            e.preventDefault();
+            last.focus();
+          }
+        } else {
+          if (document.activeElement === last) {
+            e.preventDefault();
+            first.focus();
+          }
+        }
+      }
+    };
+    el?.addEventListener('keydown', handleKeyDown);
+    return () => {
+      el?.removeEventListener('keydown', handleKeyDown);
+      prev?.focus();
+    };
+  }, [onClose]);
+
   return (
-    <div style={{ position: 'fixed', top: 0, right: 0, bottom: 0, width: 360, background: '#fff', boxShadow: '-2px 0 8px rgba(0,0,0,0.2)', padding: 16, overflowY: 'auto' }}>
-      <button onClick={onClose} style={{ float: 'right' }}>✕</button>
-      <h2>{route.name}</h2>
+    <div
+      ref={dialogRef}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="route-title"
+      tabIndex={-1}
+      style={{ position: 'fixed', top: 0, right: 0, bottom: 0, width: 360, background: '#fff', boxShadow: '-2px 0 8px rgba(0,0,0,0.2)', padding: 16, overflowY: 'auto' }}
+    >
+      <button onClick={onClose} aria-label="Close" style={{ float: 'right' }}>✕</button>
+      <h2 id="route-title">{route.name}</h2>
       <h3>Stops</h3>
       <table className="table">
         <thead>

--- a/frontend/pages/admin/assign.tsx
+++ b/frontend/pages/admin/assign.tsx
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router';
 import dynamic from 'next/dynamic';
 import { useQuery } from '@tanstack/react-query';
 import { fetchUnassigned, Order } from '@/utils/apiAdapter';
+import AdminLayout from '@/components/admin/AdminLayout';
 
 const AssignToRouteModal = dynamic(() => import('@/components/admin/AssignToRouteModal'));
 
@@ -18,10 +19,11 @@ export default function AdminAssignPage() {
     }
   }, [dateParam, date, router]);
 
-  const { data: orders } = useQuery({
+  const ordersQuery = useQuery({
     queryKey: ['unassigned', date],
     queryFn: () => fetchUnassigned(date),
   });
+  const orders = ordersQuery.data || [];
 
   const [selected, setSelected] = React.useState<Set<string>>(new Set());
   const [showCompleted, setShowCompleted] = React.useState(false);
@@ -36,18 +38,40 @@ export default function AdminAssignPage() {
     });
   };
 
-  const visible = (orders || []).filter(
+  const visible = orders.filter(
     (o) => showCompleted || (o.status !== 'SUCCESS' && o.status !== 'DELIVERED')
   );
+  const allSelected = visible.length > 0 && visible.every((o) => selected.has(o.id));
+  const someSelected = visible.some((o) => selected.has(o.id));
+  const selectAllRef = React.useRef<HTMLInputElement>(null);
+  React.useEffect(() => {
+    if (selectAllRef.current) {
+      selectAllRef.current.indeterminate = someSelected && !allSelected;
+    }
+  }, [someSelected, allSelected]);
+  const toggleAll = (checked: boolean) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      visible.forEach((o) => {
+        if (checked) next.add(o.id);
+        else next.delete(o.id);
+      });
+      return next;
+    });
+  };
 
   return (
     <div style={{ padding: 16 }}>
+      <h1>Assign Orders</h1>
       <header style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
-        <input
-          type="date"
-          value={date}
-          onChange={(e) => router.push({ pathname: '/admin/assign', query: { date: e.target.value } })}
-        />
+        <label style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+          <span>Date</span>
+          <input
+            type="date"
+            value={date}
+            onChange={(e) => router.push({ pathname: '/admin/assign', query: { date: e.target.value } })}
+          />
+        </label>
         <label>
           <input
             type="checkbox"
@@ -56,38 +80,90 @@ export default function AdminAssignPage() {
           />{' '}
           Show completed
         </label>
+        <span aria-live="polite">Selected: {selected.size}</span>
       </header>
       <table className="table" style={{ marginTop: 16 }}>
+        <caption className="sr-only">Unassigned orders</caption>
         <thead>
           <tr>
-            <th></th>
+            <th>
+              <input
+                ref={selectAllRef}
+                type="checkbox"
+                aria-label="Select all"
+                checked={allSelected}
+                onChange={(e) => toggleAll(e.target.checked)}
+              />
+            </th>
             <th>Order#</th>
             <th>Delivery Date</th>
             <th>Status</th>
           </tr>
         </thead>
         <tbody>
-          {visible.map((o: Order) => (
-            <tr key={o.id}>
-              <td>
-                <input
-                  type="checkbox"
-                  checked={selected.has(o.id)}
-                  onChange={() => toggle(o.id)}
-                />
+          {ordersQuery.isLoading && (
+            <tr>
+              <td colSpan={4} role="status">
+                Loading...
               </td>
-              <td>{o.orderNo}</td>
-              <td>{o.deliveryDate}</td>
-              <td>{o.status}</td>
             </tr>
-          ))}
+          )}
+          {ordersQuery.isError && (
+            <tr>
+              <td colSpan={4} role="alert">
+                Failed to load
+              </td>
+            </tr>
+          )}
+          {!ordersQuery.isLoading &&
+            visible.map((o: Order) => (
+              <tr key={o.id}>
+                <td>
+                  <input
+                    type="checkbox"
+                    aria-label={`Select order ${o.orderNo}`}
+                    checked={selected.has(o.id)}
+                    onChange={() => toggle(o.id)}
+                  />
+                </td>
+                <td>{o.orderNo}</td>
+                <td>{o.deliveryDate}</td>
+                <td>{o.status}</td>
+              </tr>
+            ))}
+          {!ordersQuery.isLoading && visible.length === 0 && (
+            <tr>
+              <td colSpan={4} style={{ opacity: 0.6 }}>
+                No orders
+              </td>
+            </tr>
+          )}
         </tbody>
       </table>
-      {selected.size > 0 && (
-        <button style={{ marginTop: 8 }} onClick={() => setShowModal(true)}>
+      <div
+        style={{
+          position: 'sticky',
+          bottom: 0,
+          background: '#fff',
+          paddingTop: 8,
+          paddingBottom: 8,
+          marginTop: 8,
+          display: 'flex',
+          gap: 8,
+          borderTop: '1px solid #eee',
+        }}
+      >
+        <button
+          className="btn secondary"
+          onClick={() => setSelected(new Set())}
+          disabled={selected.size === 0}
+        >
+          Clear
+        </button>
+        <button className="btn" onClick={() => setShowModal(true)} disabled={selected.size === 0}>
           Assign to route
         </button>
-      )}
+      </div>
       {showModal && (
         <AssignToRouteModal
           orderIds={[...selected]}
@@ -101,3 +177,5 @@ export default function AdminAssignPage() {
     </div>
   );
 }
+
+(AdminAssignPage as any).getLayout = (page: any) => <AdminLayout>{page}</AdminLayout>;

--- a/frontend/pages/admin/driver-commissions.tsx
+++ b/frontend/pages/admin/driver-commissions.tsx
@@ -5,20 +5,22 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { listDrivers, listDriverCommissions, addPayment, markSuccess, updateCommission } from '@/utils/api';
 import StatusBadge from '@/components/StatusBadge';
 
-export default function DriverCommissionsPage(){
+export default function DriverCommissionsPage() {
   const qc = useQueryClient();
   const [driverId, setDriverId] = React.useState<string>('');
-  const [month, setMonth] = React.useState<string>(new Date().toISOString().slice(0,7)); // yyyy-mm
+  const [month, setMonth] = React.useState<string>(new Date().toISOString().slice(0, 7)); // yyyy-mm
 
-  const { data: drivers } = useQuery({
+  const driversQuery = useQuery({
     queryKey: ['drivers'],
     queryFn: listDrivers,
   });
-  const { data: rows } = useQuery({
+  const rowsQuery = useQuery({
     queryKey: ['commissions', driverId, month],
     queryFn: () => (driverId ? listDriverCommissions(Number(driverId)) : Promise.resolve([])),
     enabled: !!driverId,
   });
+  const drivers = driversQuery.data || [];
+  const rows = rowsQuery.data || [];
 
   const payAndSuccess = useMutation({
     mutationFn: async ({ orderId, amount, method, reference }: any) => {
@@ -44,63 +46,180 @@ export default function DriverCommissionsPage(){
 
   return (
     <div>
-      <h1 style={{marginTop:0}}>Driver Commissions</h1>
-      <div className="row" style={{gap:8, marginBottom:12}}>
-        <select className="select" value={driverId} onChange={e=>setDriverId(e.target.value)}>
-          <option value="">Select driver…</option>
-          {(drivers||[]).map((d:any)=> <option key={d.id} value={d.id}>{d.name||`Driver ${d.id}`}</option>)}
-        </select>
-        <input className="input" type="month" value={month} onChange={e=>setMonth(e.target.value)} />
+      <h1 style={{ marginTop: 0 }}>Driver Commissions</h1>
+      <div className="row" style={{ gap: 8, marginBottom: 12 }}>
+        <label className="col">
+          <span>Driver</span>
+          <select
+            className="select"
+            value={driverId}
+            onChange={(e) => setDriverId(e.target.value)}
+          >
+            <option value="">Select driver…</option>
+            {drivers.map((d: any) => (
+              <option key={d.id} value={d.id}>
+                {d.name || `Driver ${d.id}`}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="col">
+          <span>Month</span>
+          <input
+            className="input"
+            type="month"
+            value={month}
+            onChange={(e) => setMonth(e.target.value)}
+          />
+        </label>
       </div>
 
       <div className="card">
         <table className="table">
-          <thead><tr><th>Order</th><th>Status</th><th>POD</th><th>Payment</th><th>Commission</th><th></th></tr></thead>
+          <thead>
+            <tr>
+              <th>Order</th>
+              <th>Status</th>
+              <th>POD</th>
+              <th>Payment</th>
+              <th>Commission</th>
+              <th></th>
+            </tr>
+          </thead>
           <tbody>
-            {(rows||[]).map((o:any)=>(
-              <OrderRow key={o.id} o={o} onPaySuccess={payAndSuccess.mutate} onSaveCommission={saveCommission.mutate} />
-            ))}
-            {(!rows || rows.length===0) && <tr><td colSpan={6} style={{opacity:.7}}>No data</td></tr>}
+            {rowsQuery.isLoading && (
+              <tr>
+                <td colSpan={6} role="status">
+                  Loading...
+                </td>
+              </tr>
+            )}
+            {rowsQuery.isError && (
+              <tr>
+                <td colSpan={6} role="alert">
+                  Failed to load
+                </td>
+              </tr>
+            )}
+            {!rowsQuery.isLoading &&
+              rows.map((o: any) => (
+                <OrderRow
+                  key={o.id}
+                  o={o}
+                  onPaySuccess={payAndSuccess.mutate}
+                  onSaveCommission={saveCommission.mutate}
+                />
+              ))}
+            {!rowsQuery.isLoading && rows.length === 0 && (
+              <tr>
+                <td colSpan={6} style={{ opacity: 0.7 }}>
+                  No data
+                </td>
+              </tr>
+            )}
           </tbody>
         </table>
       </div>
+      <p aria-live="polite" style={{ marginTop: 8, fontSize: '0.875rem', opacity: 0.7 }}>
+        {rows.length} orders loaded.
+      </p>
     </div>
   );
 }
 
-function OrderRow({ o, onPaySuccess, onSaveCommission }:{ o:any; onPaySuccess:any; onSaveCommission:any }){
-  const [method,setMethod] = React.useState('');
-  const [amount,setAmount] = React.useState('');
-  const [reference,setReference] = React.useState('');
-  const [commission,setCommission] = React.useState(String(o?.trip?.commission?.computed_amount ?? o?.commission ?? ''));
+function OrderRow({ o, onPaySuccess, onSaveCommission }: { o: any; onPaySuccess: any; onSaveCommission: any }) {
+  const [method, setMethod] = React.useState('');
+  const [amount, setAmount] = React.useState('');
+  const [reference, setReference] = React.useState('');
+  const [commission, setCommission] = React.useState(
+    String(o?.trip?.commission?.computed_amount ?? o?.commission ?? '')
+  );
 
   const pod = o?.trip?.pod_photo_url || o?.pod_photo_url;
-  const canSuccess = o.status === 'DELIVERED' && (!!pod) && ((method==='' && amount==='') || (!!method && !!amount));
+  const canSuccess =
+    o.status === 'DELIVERED' &&
+    !!pod &&
+    ((method === '' && amount === '') || (!!method && !!amount));
 
   return (
     <tr>
       <td>{o.code || o.id}</td>
       <td><StatusBadge value={o.status} /></td>
-      <td>{pod ? <a href={pod} target="_blank" rel="noreferrer"><Image src={pod} alt="POD" width={64} height={64}/></a> : <span style={{opacity:.6}}>No POD</span>}</td>
       <td>
-        <div style={{display:'flex',gap:4}}>
-          <select className="select" value={method} onChange={e=>setMethod(e.target.value)}>
+        {pod ? (
+          <a href={pod} target="_blank" rel="noreferrer">
+            <Image src={pod} alt="POD" width={64} height={64} />
+          </a>
+        ) : (
+          <span style={{ opacity: 0.6 }}>No POD</span>
+        )}
+      </td>
+      <td>
+        <div style={{ display: 'flex', gap: 4 }}>
+          <label className="sr-only" htmlFor={`method-${o.id}`}>
+            Payment method
+          </label>
+          <select
+            id={`method-${o.id}`}
+            className="select"
+            value={method}
+            onChange={(e) => setMethod(e.target.value)}
+          >
             <option value="">None</option>
             <option>Cash</option>
             <option>Online</option>
           </select>
-          <input className="input" placeholder="Amount" value={amount} onChange={e=>setAmount(e.target.value)} />
-          <input className="input" placeholder="Ref (optional)" value={reference} onChange={e=>setReference(e.target.value)} />
+          <label className="sr-only" htmlFor={`amount-${o.id}`}>
+            Amount
+          </label>
+          <input
+            id={`amount-${o.id}`}
+            className="input"
+            placeholder="Amount"
+            value={amount}
+            onChange={(e) => setAmount(e.target.value)}
+          />
+          <label className="sr-only" htmlFor={`ref-${o.id}`}>
+            Reference
+          </label>
+          <input
+            id={`ref-${o.id}`}
+            className="input"
+            placeholder="Ref (optional)"
+            value={reference}
+            onChange={(e) => setReference(e.target.value)}
+          />
         </div>
       </td>
       <td>
-        <div style={{display:'flex',gap:4}}>
-          <input className="input" placeholder="Commission" value={commission} onChange={e=>setCommission(e.target.value)} />
-          <button className="btn secondary" onClick={()=>onSaveCommission({ orderId: o.id, amount: commission })}>Save</button>
+        <div style={{ display: 'flex', gap: 4 }}>
+          <label className="sr-only" htmlFor={`commission-${o.id}`}>
+            Commission
+          </label>
+          <input
+            id={`commission-${o.id}`}
+            className="input"
+            placeholder="Commission"
+            value={commission}
+            onChange={(e) => setCommission(e.target.value)}
+          />
+          <button
+            className="btn secondary"
+            onClick={() => onSaveCommission({ orderId: o.id, amount: commission })}
+          >
+            Save
+          </button>
         </div>
       </td>
       <td>
-        <button className="btn" disabled={!canSuccess} onClick={()=>onPaySuccess({ orderId: o.id, amount, method, reference })}>Mark Success</button>
+        <button
+          className="btn"
+          disabled={!canSuccess}
+          title={!canSuccess ? 'Requires POD and valid payment (if provided)' : undefined}
+          onClick={() => onPaySuccess({ orderId: o.id, amount, method, reference })}
+        >
+          Mark Success
+        </button>
       </td>
     </tr>
   );

--- a/frontend/pages/admin/routes.tsx
+++ b/frontend/pages/admin/routes.tsx
@@ -7,6 +7,28 @@ import AdminLayout from '@/components/admin/AdminLayout';
 
 const RouteDetailDrawer = dynamic(() => import('@/components/admin/RouteDetailDrawer'));
 
+export function RouteCard({ route, onSelect }: { route: Route; onSelect: (r: Route) => void }) {
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      onSelect(route);
+    }
+  };
+  return (
+    <article
+      tabIndex={0}
+      role="button"
+      onClick={() => onSelect(route)}
+      onKeyDown={onKeyDown}
+      style={{ border: '1px solid #ccc', padding: 8, cursor: 'pointer' }}
+    >
+      <h2 style={{ marginTop: 0 }}>{route.name}</h2>
+      <div>Driver: {route.driverId || '-'}</div>
+      <div>Stops: {route.stops.length}</div>
+    </article>
+  );
+}
+
 export default function AdminRoutesPage() {
   const router = useRouter();
   const dateParam = typeof router.query.date === 'string' ? router.query.date : '';
@@ -19,45 +41,49 @@ export default function AdminRoutesPage() {
     }
   }, [dateParam, date, router]);
 
-  const { data: routes } = useQuery({
+  const routesQuery = useQuery({
     queryKey: ['routes', date],
     queryFn: () => fetchRoutes(date),
   });
-  const { data: unassigned } = useQuery({
+  const unassignedQuery = useQuery({
     queryKey: ['unassigned', date],
     queryFn: () => fetchUnassigned(date),
   });
-  const { data: onHold } = useQuery({
+  const onHoldQuery = useQuery({
     queryKey: ['onHold', date],
     queryFn: () => fetchOnHold(date),
   });
+  const routes = routesQuery.data || [];
+  const unassigned = unassignedQuery.data || [];
+  const onHold = onHoldQuery.data || [];
 
   const [selectedRoute, setSelectedRoute] = React.useState<Route | null>(null);
 
   return (
     <div style={{ padding: 16 }}>
+      <h1>Routes</h1>
       <header style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
-        <input
-          type="date"
-          value={date}
-          onChange={(e) => router.push({ pathname: '/admin/routes', query: { date: e.target.value } })}
-        />
-        <span>Routes: {routes?.length || 0}</span>
-        <span>Unassigned: {unassigned?.length || 0}</span>
-        <span>On Hold: {onHold?.length || 0}</span>
+        <label style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+          <span>Date</span>
+          <input
+            type="date"
+            value={date}
+            onChange={(e) => router.push({ pathname: '/admin/routes', query: { date: e.target.value } })}
+          />
+        </label>
+        <span aria-live="polite">Routes: {routes.length} Unassigned: {unassigned.length} On Hold: {onHold.length}</span>
       </header>
-      <div style={{ marginTop: 16, display: 'grid', gridTemplateColumns: 'repeat(auto-fill,minmax(220px,1fr))', gap: 8 }}>
-        {routes?.map((r) => (
-          <div
-            key={r.id}
-            style={{ border: '1px solid #ccc', padding: 8, cursor: 'pointer' }}
-            onClick={() => setSelectedRoute(r)}
-          >
-            <div style={{ fontWeight: 'bold' }}>{r.name}</div>
-            <div>Driver: {r.driverId || '-'}</div>
-            <div>Stops: {r.stops.length}</div>
+      <div style={{ marginTop: 16 }}>
+        {routesQuery.isLoading && <p role="status">Loading...</p>}
+        {routesQuery.isError && <p role="alert">Failed to load</p>}
+        {!routesQuery.isLoading && routes.length === 0 && <p style={{ opacity: 0.6 }}>No routes</p>}
+        {!routesQuery.isLoading && routes.length > 0 && (
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill,minmax(220px,1fr))', gap: 8 }}>
+            {routes.map((r) => (
+              <RouteCard key={r.id} route={r} onSelect={setSelectedRoute} />
+            ))}
           </div>
-        ))}
+        )}
       </div>
       {selectedRoute && (
         <RouteDetailDrawer route={selectedRoute} onClose={() => setSelectedRoute(null)} />

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -251,6 +251,16 @@ h6 {
   border: 0;
 }
 
+.not-sr-only:where(:focus, :focus-visible) {
+  position: static;
+  width: auto;
+  height: auto;
+  margin: 0;
+  overflow: visible;
+  clip: auto;
+  white-space: normal;
+}
+
 .modal-backdrop {
   position: fixed;
   inset: 0;


### PR DESCRIPTION
## Summary
- add skip link, sticky admin nav, and focusable main region
- make routes, assign, and driver commission pages accessible with labelled controls, keyboard support, and live regions
- cover nav active state, route card keyboard activation, and assign select-all with tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68ad2ded7da4832eb6d373414e334895