### PR TITLE
feat(admin): add index navigation

### DIFF
--- a/frontend/components/admin/AdminNav.tsx
+++ b/frontend/components/admin/AdminNav.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/router';
 export default function AdminNav() {
   const { pathname } = useRouter();
   const items = [
+    { href: '/admin', label: 'Home' },
     { href: '/admin/routes', label: 'Routes' },
     { href: '/admin/assign', label: 'Assign' },
     { href: '/admin/driver-commissions', label: 'Driver Commissions' },

--- a/frontend/pages/admin/index.tsx
+++ b/frontend/pages/admin/index.tsx
@@ -1,11 +1,27 @@
-import { useRouter } from 'next/router';
+import Link from 'next/link';
 import React from 'react';
+import AdminLayout from '@/components/admin/AdminLayout';
 
-export default function AdminIndex() {
-  const router = useRouter();
-  React.useEffect(() => {
-    const today = new Date().toISOString().slice(0, 10);
-    router.replace({ pathname: '/admin/routes', query: { date: today } });
-  }, [router]);
-  return null;
+export default function AdminIndexPage() {
+  const items = [
+    { href: '/admin/routes', label: 'Routes' },
+    { href: '/admin/assign', label: 'Assign' },
+    { href: '/admin/driver-commissions', label: 'Driver Commissions' },
+  ];
+  return (
+    <div>
+      <h1>Admin</h1>
+      <ul style={{ display: 'flex', flexDirection: 'column', gap: 8, padding: 0 }}>
+        {items.map((item) => (
+          <li key={item.href} style={{ listStyle: 'none' }}>
+            <Link className="btn" href={item.href}>
+              {item.label}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
 }
+
+(AdminIndexPage as any).getLayout = (page: any) => <AdminLayout>{page}</AdminLayout>;


### PR DESCRIPTION
## Summary
- Add admin dashboard index with links to key sections
- Include home link in admin navigation

## Testing
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_b_68ad48dd6484832eba17d4d5704011bd