### PR TITLE
Use front-end invoice print route

### DIFF
--- a/frontend/__tests__/orders/detail.test.tsx
+++ b/frontend/__tests__/orders/detail.test.tsx
@@ -17,7 +17,7 @@ vi.mock('@/utils/api', () => ({
   voidOrder: vi.fn(),
   markReturned: vi.fn(),
   markBuyback: vi.fn(),
-  invoicePdfUrl: vi.fn(),
+  invoicePrintUrl: vi.fn(),
   orderDue: (...args: any[]) => mockOrderDue(...args),
 }));
 

--- a/frontend/app/invoice/[id]/print/page.tsx
+++ b/frontend/app/invoice/[id]/print/page.tsx
@@ -3,5 +3,5 @@ import { sampleInvoice } from '@/lib/sampleInvoice';
 
 export default function InvoicePrintPage({ params }: { params: { id: string } }) {
   const data = { ...sampleInvoice, meta: { ...sampleInvoice.meta, number: params.id } };
-  return <InvoiceFortune500 data={data} />;
+  return <InvoiceFortune500 invoice={data} />;
 }

--- a/frontend/components/InvoiceFortune500.tsx
+++ b/frontend/components/InvoiceFortune500.tsx
@@ -61,7 +61,7 @@ export interface InvoiceData {
     accountNo: string;
     swift?: string;
     note?: string;
-    qrUrl?: string;
+    qrDataUrl?: string;
   };
   footer: {
     terms: string[];
@@ -91,8 +91,8 @@ function shadeColor(color: string, percent: number) {
 const BRAND_LOGO_URL =
   'https://static.wixstatic.com/media/20c5f7_f890d2de838e43ccb1b30e72b247f0b2~mv2.png';
 
-export default function InvoiceFortune500({ data }: { data: InvoiceData }) {
-  const { brand, meta, billTo, shipTo, items, summary, payment, footer } = data;
+export default function InvoiceFortune500({ invoice }: { invoice: InvoiceData }) {
+  const { brand, meta, billTo, shipTo, items, summary, payment, footer } = invoice;
   const logoUrl = brand.logoUrl || BRAND_LOGO_URL;
   const formatter = new Intl.NumberFormat('en-MY', {
     style: 'currency',
@@ -386,11 +386,20 @@ export default function InvoiceFortune500({ data }: { data: InvoiceData }) {
             </>
           )}
         </p>
-        {payment.qrUrl && (
+        {payment.qrDataUrl ? (
           <img
-            src={payment.qrUrl}
+            src={payment.qrDataUrl}
             alt="Payment QR code"
             style={{ marginTop: '1rem', height: '120px' }}
+          />
+        ) : (
+          <div
+            style={{
+              marginTop: '1rem',
+              height: '120px',
+              width: '120px',
+              border: '2px dashed #ddd',
+            }}
           />
         )}
       </div>
@@ -415,89 +424,4 @@ export default function InvoiceFortune500({ data }: { data: InvoiceData }) {
     </div>
   );
 }
-
-export const sampleInvoice: InvoiceData = {
-  brand: {
-    logoUrl: 'https://static.wixstatic.com/media/20c5f7_f890d2de838e43ccb1b30e72b247f0b2~mv2.png',
-    name: 'AA ALIVE SDN BHD',
-    regNo: 'MDA-Registered | 1234567-X',
-    address:
-      '10 Jalan Perusahaan Amari, Batu Caves, 68100 Kuala Lumpur, Malaysia',
-    phone: '+60 11-2868 6592',
-    email: 'contact@evin2u.com',
-    website: 'https://katil-hospital.my',
-    brandColor: '#0F766E',
-  },
-  meta: {
-    title: 'TAX INVOICE / INVOIS CUKAI',
-    number: 'INV-2025-000123',
-    issueDate: '2025-08-26',
-    dueDate: '2025-09-09',
-    currency: 'MYR',
-    taxLabel: 'SST',
-    taxId: 'SST ID: B1234567890',
-    poNumber: 'PO-778899',
-    reference: 'Order Intake Cloud',
-  },
-  billTo: {
-    label: 'Bill To / Dibayar Kepada',
-    name: 'Assunta Hospital Malaysia',
-    attn: 'Procurement Department',
-    address: 'Jalan Templer, 46990 Petaling Jaya, Selangor',
-    email: 'procurement@assunta.com',
-  },
-  shipTo: {
-    label: 'Ship To / Dihantar Ke',
-    name: 'Assunta Hospital – Receiving Bay',
-    address: 'Jalan Templer, 46990 Petaling Jaya, Selangor',
-  },
-  items: [
-    {
-      sku: 'SKB-E300',
-      name: 'Electric Hospital Bed – Hi-Lo (3-function)',
-      note: 'With side rails, ABS head/foot board',
-      qty: 8,
-      unit: 'unit',
-      unitPrice: 4200,
-      discount: 0,
-      taxRate: 0.06,
-    },
-    {
-      sku: 'MAT-PRO90',
-      name: 'Pressure-relief Mattress 90mm',
-      qty: 8,
-      unit: 'unit',
-      unitPrice: 380,
-      discount: 0.05,
-      taxRate: 0.06,
-    },
-    {
-      sku: 'SRV-INST',
-      name: 'On-site Installation & Training',
-      qty: 1,
-      unit: 'lot',
-      unitPrice: 600,
-      discount: 0,
-      taxRate: 0,
-    },
-  ],
-  summary: { shipping: 0, other: 0, rounding: 0, depositPaid: 0 },
-  payment: {
-    bankName: 'CIMB',
-    accountName: 'AA ALIVE SDN BHD',
-    accountNo: '8011366127',
-    swift: 'CIBBMYKLXXX',
-    note: 'Please pay within 14 days. Late payment may incur charges.',
-    qrUrl:
-      'https://static.wixstatic.com/media/20c5f7_98a9fa77aba04052833d15b05fadbe30~mv2.png',
-  },
-  footer: {
-    terms: [
-      'Goods remain the property of AA ALIVE SDN BHD until full payment is received.',
-      'Warranty: 12 months against manufacturing defects unless stated otherwise.',
-      'Return policy per contract. / Polisi pemulangan mengikut kontrak.',
-    ],
-    note: 'Thank you for your business! / Terima kasih atas sokongan anda!',
-  },
-};
 

--- a/frontend/lib/sampleInvoice.ts
+++ b/frontend/lib/sampleInvoice.ts
@@ -64,6 +64,7 @@ export const sampleInvoice: InvoiceData = {
     accountNo: '512345678901',
     swift: 'MBBEMYKL',
     note: 'Payment due within 14 days.',
+    qrDataUrl: 'https://static.wixstatic.com/media/20c5f7_98a9fa77aba04052833d15b05fadbe30~mv2.png',
   },
   footer: {
     terms: [

--- a/frontend/pages/orders.tsx
+++ b/frontend/pages/orders.tsx
@@ -13,7 +13,7 @@ import {
   markSuccess,
   assignOrderToDriver,
   listDrivers,
-  invoicePdfUrl,
+  invoicePrintUrl,
   orderDue,
 } from "@/utils/api";
 import Link from "next/link";
@@ -193,8 +193,7 @@ export default function OperatorOrdersPage() {
   }
 
   function openInvoice(order: any) {
-    const url = invoicePdfUrl(order.id);
-    window.open(url, "_blank");
+    window.open(invoicePrintUrl(order.id), "_blank", "noopener,noreferrer");
   }
 
   async function batchRecordPayment() {

--- a/frontend/pages/orders/[id].tsx
+++ b/frontend/pages/orders/[id].tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 import Image from "next/image";
 import { useRouter } from "next/router";
 import { useTranslation } from "react-i18next";
-import { getOrder, updateOrder, addPayment, voidPayment, voidOrder, markReturned, markBuyback, invoicePdfUrl, orderDue, markSuccess, updateCommission } from "@/utils/api";
+import { getOrder, updateOrder, addPayment, voidPayment, voidOrder, markReturned, markBuyback, invoicePrintUrl, orderDue, markSuccess, updateCommission } from "@/utils/api";
 
 export default function OrderDetailPage(){
   const router = useRouter();
@@ -92,7 +92,7 @@ export default function OrderDetailPage(){
 
   if(!order) return <div className="card">Loading...</div>;
   const profile = order.company_profile || {};
-  const invoiceUrl = invoicePdfUrl(order.id);
+  const invoiceUrl = invoicePrintUrl(order.id);
   function copyInvoice(){ navigator.clipboard.writeText(invoiceUrl); alert(t('documents.copied')); }
 
   function updateItem(idx:number, field:string, value:any){
@@ -254,7 +254,7 @@ export default function OrderDetailPage(){
             <div className="card">
             <div style={{display:"flex",justifyContent:"space-between",alignItems:"center"}}>
               <h2 style={{marginTop:0}}>{order.code || order.id} <span className="badge">{order.status}</span></h2>
-              <a className="btn secondary" href={invoicePdfUrl(order.id)} target="_blank" rel="noreferrer">
+              <a className="btn secondary" href={invoicePrintUrl(order.id)} target="_blank" rel="noreferrer">
                 Invoice PDF
               </a>
             </div>

--- a/frontend/utils/api.ts
+++ b/frontend/utils/api.ts
@@ -283,6 +283,10 @@ export function invoicePdfUrl(orderId: number) {
   return `${base}/documents/invoice/${orderId}.pdf`;
 }
 
+export function invoicePrintUrl(orderId: number | string) {
+  return `/invoice/${orderId}/print`;
+}
+
 // -------- Drivers
 export function listDrivers() {
   return request<any[]>("/drivers");


### PR DESCRIPTION
## Summary
- add invoicePrintUrl helper and route all UI invoice links through `/invoice/<id>/print`
- render InvoiceFortune500 with invoice data and QR placeholder
- include sample invoice with QR data URL for demo

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68ad4a342918832ea25a3162ca428b59