### PR TITLE
feat: unify API base handling and improve request helper

### DIFF
--- a/frontend/__tests__/api-request.test.ts
+++ b/frontend/__tests__/api-request.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect, vi } from 'vitest';
+import { request } from '@/utils/api';
+
+describe('api request', () => {
+  it('uses provided method even with json body', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      text: async () => '',
+      headers: { get: () => 'application/json' },
+    });
+    (global as any).fetch = mockFetch;
+
+    await request('/test', { method: 'DELETE', json: { foo: 'bar' } });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining('/test'),
+      expect.objectContaining({
+        method: 'DELETE',
+        body: JSON.stringify({ foo: 'bar' }),
+      })
+    );
+  });
+});

--- a/frontend/pages/admin/assign.tsx
+++ b/frontend/pages/admin/assign.tsx
@@ -111,7 +111,7 @@ export default function AdminAssignPage() {
           {ordersQuery.isError && (
             <tr>
               <td colSpan={4} role="alert">
-                Failed to load
+                {(ordersQuery.error as any)?.message || 'Failed to load'}
               </td>
             </tr>
           )}

--- a/frontend/pages/admin/driver-commissions.tsx
+++ b/frontend/pages/admin/driver-commissions.tsx
@@ -97,7 +97,7 @@ export default function DriverCommissionsPage() {
             {rowsQuery.isError && (
               <tr>
                 <td colSpan={6} role="alert">
-                  Failed to load
+                  {(rowsQuery.error as any)?.message || 'Failed to load'}
                 </td>
               </tr>
             )}

--- a/frontend/pages/admin/routes.tsx
+++ b/frontend/pages/admin/routes.tsx
@@ -75,7 +75,11 @@ export default function AdminRoutesPage() {
       </header>
       <div style={{ marginTop: 16 }}>
         {routesQuery.isLoading && <p role="status">Loading...</p>}
-        {routesQuery.isError && <p role="alert">Failed to load</p>}
+        {routesQuery.isError && (
+          <p role="alert">
+            {(routesQuery.error as any)?.message || 'Failed to load'}
+          </p>
+        )}
         {!routesQuery.isLoading && routes.length === 0 && <p style={{ opacity: 0.6 }}>No routes</p>}
         {!routesQuery.isLoading && routes.length > 0 && (
           <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill,minmax(220px,1fr))', gap: 8 }}>

--- a/frontend/pages/export.tsx
+++ b/frontend/pages/export.tsx
@@ -1,12 +1,13 @@
 import Card from "@/components/Card";
 import Button from "@/components/ui/button";
 import React from "react";
+import { apiBase } from "@/utils/api";
 
 export default function ExportPage() {
   const [start, setStart] = React.useState("");
   const [end, setEnd] = React.useState("");
   const [mark, setMark] = React.useState(false);
-  const base = process.env.NEXT_PUBLIC_API_URL || "/_api";
+  const base = apiBase();
 
   function download(kind: "cash" | "payments_received") {
     if (!start || !end) return;

--- a/frontend/pages/orders.tsx
+++ b/frontend/pages/orders.tsx
@@ -15,6 +15,7 @@ import {
   listDrivers,
   invoicePrintUrl,
   orderDue,
+  apiBase,
 } from "@/utils/api";
 import Link from "next/link";
 
@@ -218,7 +219,7 @@ export default function OperatorOrdersPage() {
   }
 
   function batchExport() {
-    const base = process.env.NEXT_PUBLIC_API_URL || "/_api";
+    const base = apiBase();
     const ids = Array.from(selected).join(",");
     const url = `${base}/orders/export.xlsx?ids=${ids}`;
     if (typeof window !== "undefined") window.open(url, "_blank");

--- a/frontend/utils/apiAdapter.ts
+++ b/frontend/utils/apiAdapter.ts
@@ -1,4 +1,10 @@
-import { listRoutes, listOrders, addOrdersToRoute, createRoute as apiCreateRoute } from './api';
+import {
+  listRoutes,
+  listOrders,
+  addOrdersToRoute,
+  createRoute as apiCreateRoute,
+  request,
+} from './api';
 
 export type Order = {
   id: string;
@@ -125,22 +131,12 @@ export async function assignOrdersToRoute(
   await addOrdersToRoute(Number(routeId), orderIds.map((o) => Number(o)));
 }
 
-function apiBase() {
-  const envBase = (process.env.NEXT_PUBLIC_API_URL || '').replace(/\/+$/, '');
-  return envBase || '/_api';
-}
-
 export async function removeOrdersFromRoute(
   routeId: string,
   orderIds: string[],
 ): Promise<void> {
-  const res = await fetch(`${apiBase()}/routes/${routeId}/orders`, {
+  await request(`/routes/${routeId}/orders`, {
     method: 'DELETE',
-    headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
-    credentials: 'include',
-    body: JSON.stringify({ order_ids: orderIds.map((o) => Number(o)) }),
+    json: { order_ids: orderIds.map((o) => Number(o)) },
   });
-  if (!res.ok) {
-    throw new Error(`Failed to remove orders: ${res.status}`);
-  }
 }


### PR DESCRIPTION
## Summary
- centralize API base resolution with new `getApiBase`/`apiBase`
- allow overriding HTTP method when sending JSON bodies
- use shared request helper in apiAdapter and pages
- surface actual error messages on admin pages
- add tests for method override in request

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68adeaa24a58832eb5320e193aca0b6c