### PR TITLE
Fix server invoice print by forwarding cookies

### DIFF
--- a/frontend/utils/apiAdapter.ts
+++ b/frontend/utils/apiAdapter.ts
@@ -105,7 +105,7 @@ export async function fetchOnHold(date: string): Promise<Order[]> {
     .filter(
       (o) =>
         o.deliveryDate === date &&
-        o.trip?.status === 'ON_HOLD' &&
+        (o.status === 'ON_HOLD' || o.trip?.status === 'ON_HOLD') &&
         o.status !== 'SUCCESS' &&
         o.status !== 'DELIVERED'
     );


### PR DESCRIPTION
## Summary
- Forward request cookies in `utils/api` when running on the server
- Correct `fetchOnHold` to detect orders with `status: ON_HOLD`
- Add test covering server-side cookie forwarding

## Testing
- `npm --prefix frontend test`


------
https://chatgpt.com/codex/tasks/task_b_68adf3de7f64832e9ffb95219b24cdca