### PR TITLE
Implement server-side order date filtering

### DIFF
--- a/frontend/__tests__/apiAdapter.test.ts
+++ b/frontend/__tests__/apiAdapter.test.ts
@@ -35,16 +35,23 @@ describe('apiAdapter', () => {
     });
   });
 
-  it('filters unassigned orders by date and status', async () => {
-    (api.listOrders as any).mockResolvedValue({ items: [sampleOrder, { ...sampleOrder, id: 11, status: 'SUCCESS' }] });
+  it('fetchUnassigned passes server-side filters', async () => {
+    (api.listOrders as any).mockResolvedValue({ items: [sampleOrder] });
     const orders = await fetchUnassigned('2024-05-25');
+    expect(api.listOrders).toHaveBeenCalledWith(undefined, undefined, undefined, 500, {
+      date: '2024-05-25',
+      unassigned: true,
+    });
     expect(orders).toHaveLength(1);
     expect(orders[0].id).toBe('10');
   });
 
-  it('fetchOnHold filters status', async () => {
-    (api.listOrders as any).mockResolvedValue({ items: [{ ...sampleOrder, status: 'ON_HOLD' }, { ...sampleOrder, id: 12, status: 'DELIVERED' }] });
+  it('fetchOnHold forwards date and status filters', async () => {
+    (api.listOrders as any).mockResolvedValue({ items: [{ ...sampleOrder, status: 'ON_HOLD' }] });
     const orders = await fetchOnHold('2024-05-25');
+    expect(api.listOrders).toHaveBeenCalledWith(undefined, 'ON_HOLD', undefined, 500, {
+      date: '2024-05-25',
+    });
     expect(orders).toHaveLength(1);
     expect(orders[0].status).toBe('ON_HOLD');
   });

--- a/frontend/pages/admin/assign.tsx
+++ b/frontend/pages/admin/assign.tsx
@@ -10,7 +10,7 @@ const AssignToRouteModal = dynamic(() => import('@/components/admin/AssignToRout
 export default function AdminAssignPage() {
   const router = useRouter();
   const dateParam = typeof router.query.date === 'string' ? router.query.date : '';
-  const today = new Date().toISOString().slice(0, 10);
+  const today = new Date().toLocaleDateString('en-CA');
   const date = dateParam || today;
 
   React.useEffect(() => {

--- a/frontend/pages/admin/routes.tsx
+++ b/frontend/pages/admin/routes.tsx
@@ -32,7 +32,7 @@ export function RouteCard({ route, onSelect }: { route: Route; onSelect: (r: Rou
 export default function AdminRoutesPage() {
   const router = useRouter();
   const dateParam = typeof router.query.date === 'string' ? router.query.date : '';
-  const today = new Date().toISOString().slice(0, 10);
+  const today = new Date().toLocaleDateString('en-CA');
   const date = dateParam || today;
 
   React.useEffect(() => {

--- a/frontend/utils/api.ts
+++ b/frontend/utils/api.ts
@@ -85,13 +85,16 @@ export async function listOrders(
   q?: string,
   status?: string,
   type?: string,
-  limit?: number
+  limit?: number,
+  opts?: { date?: string; unassigned?: boolean }
 ): Promise<OrdersList> {
   const sp = new URLSearchParams();
   if (q) sp.set("q", q);
   if (status) sp.set("status", status);
   if (type) sp.set("type", type);
   if (limit) sp.set("limit", String(limit));
+  if (opts?.date) sp.set("date", opts.date);
+  if (opts?.unassigned) sp.set("unassigned", "true");
   const qs = sp.toString();
 
   const data = await request<any>(`/orders${qs ? `?${qs}` : ""}`);

--- a/frontend/utils/apiAdapter.ts
+++ b/frontend/utils/apiAdapter.ts
@@ -86,29 +86,16 @@ export async function fetchRoutes(date: string): Promise<Route[]> {
 }
 
 export async function fetchUnassigned(date: string): Promise<Order[]> {
-  const { items } = await listOrders(undefined, undefined, undefined, 500);
-  return items
-    .map(mapOrder)
-    .filter(
-      (o) =>
-        o.deliveryDate === date &&
-        !o.trip &&
-        o.status !== 'SUCCESS' &&
-        o.status !== 'DELIVERED'
-    );
+  const { items } = await listOrders(undefined, undefined, undefined, 500, {
+    date,
+    unassigned: true,
+  });
+  return (items || []).map(mapOrder);
 }
 
 export async function fetchOnHold(date: string): Promise<Order[]> {
-  const { items } = await listOrders(undefined, undefined, undefined, 500);
-  return items
-    .map(mapOrder)
-    .filter(
-      (o) =>
-        o.deliveryDate === date &&
-        (o.status === 'ON_HOLD' || o.trip?.status === 'ON_HOLD') &&
-        o.status !== 'SUCCESS' &&
-        o.status !== 'DELIVERED'
-    );
+  const { items } = await listOrders(undefined, 'ON_HOLD', undefined, 500, { date });
+  return (items || []).map(mapOrder);
 }
 
 export async function createRoute(payload: {


### PR DESCRIPTION
## Summary
- add optional `date` and `unassigned` filters to `GET /orders`
- send these filters from `listOrders` and use them in `fetchUnassigned` and `fetchOnHold`
- derive admin pages' default dates using local time instead of UTC

## Testing
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68adf9de63e4832ebf5ea8c51aa66e1e