### PR TITLE
Fix invoice print component prop mismatch

### DIFF
--- a/frontend/app/invoice/[id]/print/page.tsx
+++ b/frontend/app/invoice/[id]/print/page.tsx
@@ -55,8 +55,7 @@ export default function InvoicePrintPage() {
 
   return (
     <div className="p-4">
-      {/* @ts-expect-error Invoice component expects different props */}
-      <InvoiceFortune500 order={order} printMode />
+      <InvoiceFortune500 invoice={order} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- pass `invoice` prop to `InvoiceFortune500` instead of `order`
- remove leftover type suppression

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68adfa7d73b8832e8b1dc9332d15d8dd