### PR TITLE
Handle missing brand data in invoice component

### DIFF
--- a/frontend/app/invoice/[id]/print/page.tsx
+++ b/frontend/app/invoice/[id]/print/page.tsx
@@ -55,8 +55,7 @@ export default function InvoicePrintPage() {
 
   return (
     <div className="p-4">
-      {/* @ts-expect-error Invoice component expects different props */}
-      <InvoiceFortune500 order={order} printMode />
+      <InvoiceFortune500 invoice={order} />
     </div>
   );
 }

--- a/frontend/components/InvoiceFortune500.tsx
+++ b/frontend/components/InvoiceFortune500.tsx
@@ -13,15 +13,15 @@ export interface InvoiceItem {
 }
 
 export interface InvoiceData {
-  brand: {
+  brand?: {
     logoUrl?: string;
-    name: string;
+    name?: string;
     regNo?: string;
     address?: string;
     phone?: string;
     email?: string;
     website?: string;
-    brandColor: string;
+    brandColor?: string;
   };
   meta: {
     title: string;
@@ -92,7 +92,13 @@ const BRAND_LOGO_URL =
   'https://static.wixstatic.com/media/20c5f7_f890d2de838e43ccb1b30e72b247f0b2~mv2.png';
 
 export default function InvoiceFortune500({ invoice }: { invoice: InvoiceData }) {
-  const { brand, meta, billTo, shipTo, items, summary, payment, footer } = invoice;
+  const { meta, billTo, shipTo, items, summary, payment, footer } = invoice;
+  const brand = {
+    logoUrl: BRAND_LOGO_URL,
+    name: '',
+    brandColor: '#000',
+    ...(invoice.brand ?? {}),
+  };
   const logoUrl = brand.logoUrl || BRAND_LOGO_URL;
   const formatter = new Intl.NumberFormat('en-MY', {
     style: 'currency',
@@ -115,7 +121,7 @@ export default function InvoiceFortune500({ invoice }: { invoice: InvoiceData })
     (summary.rounding || 0) -
     (summary.depositPaid || 0);
 
-  const gradientTo = shadeColor(brand.brandColor, 40);
+  const gradientTo = shadeColor(brand.brandColor || '#000', 40);
 
   return (
     <div className="invoice-f500">


### PR DESCRIPTION
## Summary
- avoid crashes when invoice `brand` info is missing by defaulting logo and color
- allow `InvoiceData` to omit `brand` information

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_b_68adfa7d73b8832e8b1dc9332d15d8dd