### PR TITLE
Show assigned orders in route drawer

### DIFF
--- a/backend/app/routers/orders.py
+++ b/backend/app/routers/orders.py
@@ -98,6 +98,7 @@ def list_orders(
                 "driver_id": trip.driver_id,
                 "status": trip.status,
                 "driver_name": driver_name,
+                "route_id": trip.route_id,
             }
         out.append(OrderListOut.model_validate(dto))
     return envelope(out)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -124,6 +124,7 @@ class TripOut(BaseModel):
     driver_id: int
     status: str
     driver_name: str | None = None
+    route_id: int | None = None
     commission: CommissionOut | None = None
 
     class Config:

--- a/frontend/__tests__/apiAdapter.test.ts
+++ b/frontend/__tests__/apiAdapter.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { fetchRoutes, fetchUnassigned, fetchOnHold } from '../utils/apiAdapter';
+import { fetchRoutes, fetchUnassigned, fetchOnHold, fetchRouteOrders } from '../utils/apiAdapter';
 
 import * as api from '../utils/api';
 
@@ -54,5 +54,20 @@ describe('apiAdapter', () => {
     });
     expect(orders).toHaveLength(1);
     expect(orders[0].status).toBe('ON_HOLD');
+  });
+
+  it('fetchRouteOrders filters orders by route id', async () => {
+    (api.listOrders as any).mockResolvedValue({
+      items: [
+        { ...sampleOrder, trip: { route_id: 1 } },
+        { ...sampleOrder, id: 11, trip: { route_id: 2 } },
+      ],
+    });
+    const orders = await fetchRouteOrders('1', '2024-05-25');
+    expect(api.listOrders).toHaveBeenCalledWith(undefined, undefined, undefined, 500, {
+      date: '2024-05-25',
+    });
+    expect(orders).toHaveLength(1);
+    expect(orders[0].routeId).toBe('1');
   });
 });

--- a/frontend/__tests__/route-detail-drawer.test.tsx
+++ b/frontend/__tests__/route-detail-drawer.test.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { vi } from 'vitest';
+import RouteDetailDrawer from '@/components/admin/RouteDetailDrawer';
+
+vi.mock('@tanstack/react-query', async () => {
+  const actual = await vi.importActual<any>('@tanstack/react-query');
+  return {
+    ...actual,
+    useQuery: ({ queryKey }: any) => {
+      if (Array.isArray(queryKey) && queryKey[0] === 'route-orders') {
+        return {
+          data: [
+            {
+              id: '1',
+              orderNo: 'ORD1',
+              status: 'ASSIGNED',
+              deliveryDate: '2024-07-01',
+            },
+          ],
+          isLoading: false,
+          isError: false,
+        };
+      }
+      return { data: [], isLoading: false, isError: false };
+    },
+    useMutation: () => ({ mutate: vi.fn() }),
+    useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+  };
+});
+
+describe('RouteDetailDrawer', () => {
+  it('shows orders assigned to the route', () => {
+    const route = { id: '1', name: 'Route A', date: '2024-07-01' } as any;
+    render(<RouteDetailDrawer route={route} onClose={() => {}} />);
+    expect(screen.getByText('ORD1')).toBeInTheDocument();
+  });
+});
+

--- a/frontend/utils/apiAdapter.ts
+++ b/frontend/utils/apiAdapter.ts
@@ -49,7 +49,10 @@ function mapOrder(o: any): Order {
     size: o.size,
     weightKg: o.weight_kg ?? o.weightKg,
     priority: o.priority,
-    routeId: o.route_id ?? o.routeId ?? o.trip?.route_id ?? null,
+    routeId:
+      o.route_id?.toString() ??
+      o.routeId?.toString() ??
+      (o.trip?.route_id != null ? String(o.trip.route_id) : null),
     notes: o.notes || '',
     trip: o.trip,
   };
@@ -96,6 +99,13 @@ export async function fetchUnassigned(date: string): Promise<Order[]> {
 export async function fetchOnHold(date: string): Promise<Order[]> {
   const { items } = await listOrders(undefined, 'ON_HOLD', undefined, 500, { date });
   return (items || []).map(mapOrder);
+}
+
+export async function fetchRouteOrders(routeId: string, date: string): Promise<Order[]> {
+  const { items } = await listOrders(undefined, undefined, undefined, 500, { date });
+  return (items || [])
+    .filter((o: any) => o.trip?.route_id === Number(routeId))
+    .map(mapOrder);
 }
 
 export async function createRoute(payload: {


### PR DESCRIPTION
## Summary
- expose trip route IDs in order API responses
- load and display orders assigned to a route in the admin route drawer
- add tests for fetching and displaying route orders

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68adfcf339f0832eace059946f027b62