### PR TITLE
fix: handle missing params in invoice print page

### DIFF
--- a/frontend/app/invoice/[id]/print/page.tsx
+++ b/frontend/app/invoice/[id]/print/page.tsx
@@ -3,7 +3,10 @@
 import { useParams } from "next/navigation";
 
 export default function InvoicePrintPage() {
-  const { id } = useParams<{ id: string }>();
+  const params = useParams<{ id: string }>();
+  if (!params) return null;
+  const { id } = params;
+
   return (
     <iframe
       src={`/_api/orders/${id}/invoice.pdf`}


### PR DESCRIPTION
## Summary
- guard against missing params in invoice print page

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68ae41b9af20832ea75bd938cf005184