### PR TITLE
feat: backlog orders and admin badges

### DIFF
--- a/backend/tests/test_orders_backlog.py
+++ b/backend/tests/test_orders_backlog.py
@@ -1,0 +1,235 @@
+import sys
+from pathlib import Path
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, Integer
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+
+# Ensure backend package importable
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app.main import app  # noqa: E402
+from app.db import get_session  # noqa: E402
+from app.models import (
+    Base,
+    Customer,
+    Order,
+    Driver,
+    Trip,
+    OrderItem,
+    Payment,
+    Plan,
+    Role,
+)  # noqa: E402
+from app.routers import orders as orders_router  # noqa: E402
+
+
+APP_TZ = ZoneInfo("Asia/Kuala_Lumpur")
+
+
+def _setup_db():
+    engine = create_engine(
+        "sqlite://",
+        future=True,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Customer.__table__.c.id.type = Integer()
+    Order.__table__.c.id.type = Integer()
+    Order.__table__.c.customer_id.type = Integer()
+    Driver.__table__.c.id.type = Integer()
+    Trip.__table__.c.id.type = Integer()
+    Trip.__table__.c.order_id.type = Integer()
+    Trip.__table__.c.driver_id.type = Integer()
+    Trip.__table__.c.route_id.type = Integer()
+    OrderItem.__table__.c.id.type = Integer()
+    OrderItem.__table__.c.order_id.type = Integer()
+    Payment.__table__.c.id.type = Integer()
+    Payment.__table__.c.order_id.type = Integer()
+    Plan.__table__.c.id.type = Integer()
+    Plan.__table__.c.order_id.type = Integer()
+    Base.metadata.create_all(
+        engine,
+        tables=[
+            Customer.__table__,
+            Order.__table__,
+            Driver.__table__,
+            Trip.__table__,
+            OrderItem.__table__,
+            Payment.__table__,
+            Plan.__table__,
+        ],
+    )
+    return sessionmaker(bind=engine, expire_on_commit=False)
+
+
+def _override_auth():
+    class DummyUser:
+        id = 1
+        role = Role.ADMIN
+
+    dep = orders_router.router.dependencies[0].dependency
+    app.dependency_overrides[dep] = lambda: DummyUser()
+
+
+def test_unassigned_backlog_includes_null_and_overdue():
+    SessionLocal = _setup_db()
+
+    def override_get_session():
+        with SessionLocal() as session:
+            yield session
+
+    app.dependency_overrides[get_session] = override_get_session
+    _override_auth()
+
+    client = TestClient(app)
+    d = datetime(2025, 8, 27, tzinfo=APP_TZ).date()
+
+    with SessionLocal() as db:
+        customer = Customer(name="C1")
+        db.add(customer)
+        db.flush()
+        db.add_all(
+            [
+                Order(code="O1", type="OUTRIGHT", status="NEW", customer_id=customer.id, delivery_date=None),
+                Order(
+                    code="O2",
+                    type="OUTRIGHT",
+                    status="NEW",
+                    customer_id=customer.id,
+                    delivery_date=datetime(2025, 8, 25, 0, 0, tzinfo=APP_TZ),
+                ),
+                Order(
+                    code="O3",
+                    type="OUTRIGHT",
+                    status="NEW",
+                    customer_id=customer.id,
+                    delivery_date=datetime(2025, 8, 26, 0, 0, tzinfo=APP_TZ),
+                ),
+                Order(
+                    code="O4",
+                    type="OUTRIGHT",
+                    status="NEW",
+                    customer_id=customer.id,
+                    delivery_date=datetime(2025, 8, 27, 0, 0, tzinfo=APP_TZ),
+                ),
+            ]
+        )
+        db.commit()
+
+    resp = client.get("/orders", params={"date": d.isoformat(), "unassigned": "true", "limit": 500})
+    assert resp.status_code == 200
+    data = resp.json()["data"]
+    assert {o["code"] for o in data} == {"O1", "O2", "O3", "O4"}
+
+    app.dependency_overrides.clear()
+
+
+def test_on_hold_backlog_includes_null_and_overdue():
+    SessionLocal = _setup_db()
+
+    def override_get_session():
+        with SessionLocal() as session:
+            yield session
+
+    app.dependency_overrides[get_session] = override_get_session
+    _override_auth()
+
+    client = TestClient(app)
+    d = datetime(2025, 8, 27, tzinfo=APP_TZ).date()
+
+    with SessionLocal() as db:
+        customer = Customer(name="C1")
+        db.add(customer)
+        db.flush()
+        db.add_all(
+            [
+                Order(code="H1", type="OUTRIGHT", status="ON_HOLD", customer_id=customer.id, delivery_date=None),
+                Order(
+                    code="H2",
+                    type="OUTRIGHT",
+                    status="ON_HOLD",
+                    customer_id=customer.id,
+                    delivery_date=datetime(2025, 8, 25, 0, 0, tzinfo=APP_TZ),
+                ),
+                Order(
+                    code="H3",
+                    type="OUTRIGHT",
+                    status="ON_HOLD",
+                    customer_id=customer.id,
+                    delivery_date=datetime(2025, 8, 26, 0, 0, tzinfo=APP_TZ),
+                ),
+                Order(
+                    code="H4",
+                    type="OUTRIGHT",
+                    status="ON_HOLD",
+                    customer_id=customer.id,
+                    delivery_date=datetime(2025, 8, 27, 0, 0, tzinfo=APP_TZ),
+                ),
+            ]
+        )
+        db.commit()
+
+    resp = client.get("/orders", params={"date": d.isoformat(), "status": "ON_HOLD", "limit": 500})
+    assert resp.status_code == 200
+    data = resp.json()["data"]
+    assert {o["code"] for o in data} == {"H1", "H2", "H3", "H4"}
+
+    app.dependency_overrides.clear()
+
+
+def test_date_filter_exact_day_when_not_backlog():
+    SessionLocal = _setup_db()
+
+    def override_get_session():
+        with SessionLocal() as session:
+            yield session
+
+    app.dependency_overrides[get_session] = override_get_session
+    _override_auth()
+
+    client = TestClient(app)
+    d = datetime(2025, 8, 27, tzinfo=APP_TZ).date()
+
+    with SessionLocal() as db:
+        customer = Customer(name="C1")
+        db.add(customer)
+        db.flush()
+        db.add_all(
+            [
+                Order(
+                    code="E1",
+                    type="OUTRIGHT",
+                    status="NEW",
+                    customer_id=customer.id,
+                    delivery_date=datetime(2025, 8, 27, 0, 0, tzinfo=APP_TZ),
+                ),
+                Order(
+                    code="E2",
+                    type="OUTRIGHT",
+                    status="NEW",
+                    customer_id=customer.id,
+                    delivery_date=datetime(2025, 8, 27, 0, 0, tzinfo=APP_TZ),
+                ),
+                Order(
+                    code="E3",
+                    type="OUTRIGHT",
+                    status="NEW",
+                    customer_id=customer.id,
+                    delivery_date=datetime(2025, 8, 26, 0, 0, tzinfo=APP_TZ),
+                ),
+            ]
+        )
+        db.commit()
+
+    resp = client.get("/orders", params={"date": d.isoformat(), "limit": 500})
+    assert resp.status_code == 200
+    data = resp.json()["data"]
+    assert {o["code"] for o in data} == {"E1", "E2"}
+
+    app.dependency_overrides.clear()
+

--- a/frontend/__tests__/orderBadges.test.ts
+++ b/frontend/__tests__/orderBadges.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { getOrderBadges } from '@/utils/orderBadges';
+
+describe('getOrderBadges', () => {
+  it('flags missing delivery date', () => {
+    expect(getOrderBadges({ deliveryDate: null }, '2025-08-27')).toEqual(['No date']);
+  });
+
+  it('flags overdue orders', () => {
+    const badges = getOrderBadges(
+      { deliveryDate: '2025-08-25T10:00:00+08:00' },
+      '2025-08-27',
+    );
+    expect(badges).toEqual(['Overdue 2 days']);
+  });
+
+  it('returns empty for on-time orders', () => {
+    const badges = getOrderBadges(
+      { deliveryDate: '2025-08-27T09:00:00+08:00' },
+      '2025-08-27',
+    );
+    expect(badges).toEqual([]);
+  });
+});
+

--- a/frontend/components/admin/RouteDetailDrawer.tsx
+++ b/frontend/components/admin/RouteDetailDrawer.tsx
@@ -7,6 +7,7 @@ import {
   removeOrdersFromRoute,
   fetchRouteOrders,
 } from '@/utils/apiAdapter';
+import { getOrderBadges } from '@/utils/orderBadges';
 
 interface Props {
   route: Route;
@@ -30,13 +31,17 @@ export default function RouteDetailDrawer({ route, onClose }: Props) {
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ['routes', route.date] });
       qc.invalidateQueries({ queryKey: ['unassigned', route.date] });
+      qc.invalidateQueries({ queryKey: ['route-orders', route.id, route.date] });
     },
   });
 
   const removeMutation = useMutation({
     mutationFn: (orderId: string) => removeOrdersFromRoute(route.id, [orderId]),
-    onSuccess: () =>
-      qc.invalidateQueries({ queryKey: ['routes', route.date] }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['routes', route.date] });
+      qc.invalidateQueries({ queryKey: ['unassigned', route.date] });
+      qc.invalidateQueries({ queryKey: ['route-orders', route.id, route.date] });
+    },
   });
 
   const dialogRef = React.useRef<HTMLDivElement>(null);
@@ -128,6 +133,11 @@ export default function RouteDetailDrawer({ route, onClose }: Props) {
             {unassigned.map((o: Order) => (
               <li key={o.id} style={{ marginBottom: 4 }}>
                 {o.orderNo}{' '}
+                {getOrderBadges(o, route.date).map((b) => (
+                  <span key={b} style={{ marginLeft: 4, fontSize: '0.8em', color: '#c00' }}>
+                    {b}
+                  </span>
+                ))}{' '}
                 <button onClick={() => assignMutation.mutate(o.id)}>Add</button>
               </li>
             ))}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@tanstack/react-query": "^5.40.0",
         "clsx": "^2.1.1",
+        "dayjs": "^1.11.13",
         "i18next": "^25.4.0",
         "lucide-react": "^0.541.0",
         "next": "14.2.5",
@@ -7810,6 +7811,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
+      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,8 +12,9 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "clsx": "^2.1.1",
     "@tanstack/react-query": "^5.40.0",
+    "clsx": "^2.1.1",
+    "dayjs": "^1.11.13",
     "i18next": "^25.4.0",
     "lucide-react": "^0.541.0",
     "next": "14.2.5",
@@ -31,12 +32,12 @@
     "@types/node": "20.12.13",
     "@types/react": "18.3.3",
     "@vitejs/plugin-react": "^4.2.1",
+    "autoprefixer": "^10.4.15",
     "eslint": "8.57.1",
     "eslint-config-next": "14.2.5",
     "jsdom": "^24.0.0",
     "postcss": "^8.4.38",
     "tailwindcss": "^3.4.4",
-    "autoprefixer": "^10.4.15",
     "typescript": "5.4.5",
     "vite": "^5.2.0",
     "vitest": "^1.3.1"

--- a/frontend/utils/orderBadges.ts
+++ b/frontend/utils/orderBadges.ts
@@ -1,0 +1,27 @@
+// utils/orderBadges.ts
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+import tz from 'dayjs/plugin/timezone';
+
+dayjs.extend(utc);
+dayjs.extend(tz);
+
+export function getOrderBadges(
+  order: { deliveryDate: string | null },
+  selectedDateISO: string,
+): string[] {
+  const badges: string[] = [];
+  if (!order.deliveryDate) {
+    badges.push('No date');
+    return badges;
+  }
+
+  const dLocal = dayjs(order.deliveryDate).tz('Asia/Kuala_Lumpur').endOf('day');
+  const selected = dayjs(selectedDateISO).tz('Asia/Kuala_Lumpur').endOf('day');
+  const overdueDays = selected.diff(dLocal, 'day');
+  if (overdueDays > 0) {
+    badges.push(`Overdue ${overdueDays} day${overdueDays > 1 ? 's' : ''}`);
+  }
+  return badges;
+}
+


### PR DESCRIPTION
## Summary
- add KL timezone backlog filter for orders endpoint and include null delivery dates
- display "No date" and "Overdue" badges on admin assign and route details, add dayjs dependency
- cover backlog and badge logic with tests

## Testing
- `cd backend && pytest`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_b_68ae45944ce4832eb153133d35fcc14a