### PR TITLE
feat(admin): add create and edit route controls

### DIFF
--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -208,6 +208,13 @@ class RouteCreateIn(BaseModel):
     notes: str | None = None
 
 
+class RouteUpdateIn(BaseModel):
+    driver_id: int | None = None
+    route_date: str | None = None
+    name: str | None = None
+    notes: str | None = None
+
+
 class RouteOut(BaseModel):
     id: int
     driver_id: int

--- a/backend/tests/test_route_update.py
+++ b/backend/tests/test_route_update.py
@@ -1,0 +1,64 @@
+import sys
+from pathlib import Path
+from datetime import date
+
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, Integer
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app.main import app  # noqa: E402
+from app.db import get_session  # noqa: E402
+from app.models import Base, Driver, DriverRoute, Role  # noqa: E402
+from app.routers import routes as routes_router  # noqa: E402
+
+
+def _setup_db():
+    engine = create_engine(
+        "sqlite://",
+        future=True,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Driver.__table__.c.id.type = Integer()
+    DriverRoute.__table__.c.id.type = Integer()
+    DriverRoute.__table__.c.driver_id.type = Integer()
+    Base.metadata.create_all(engine, tables=[Driver.__table__, DriverRoute.__table__])
+    return sessionmaker(bind=engine, expire_on_commit=False)
+
+
+def test_update_route(monkeypatch):
+    SessionLocal = _setup_db()
+
+    def override_get_session():
+        with SessionLocal() as session:
+            yield session
+
+    app.dependency_overrides[get_session] = override_get_session
+
+    class DummyUser:
+        id = 1
+        role = Role.ADMIN
+
+    dep = routes_router.router.dependencies[0].dependency
+    app.dependency_overrides[dep] = lambda: DummyUser()
+
+    client = TestClient(app)
+
+    with SessionLocal() as db:
+        driver = Driver(firebase_uid="u1", name="D1")
+        db.add(driver)
+        db.flush()
+        route = DriverRoute(driver_id=driver.id, route_date=date(2024, 1, 1), name="R1")
+        db.add(route)
+        db.commit()
+        db.refresh(route)
+
+    resp = client.patch(f"/routes/{route.id}", json={"name": "New Name"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["name"] == "New Name"
+
+    app.dependency_overrides.clear()

--- a/frontend/components/admin/RouteFormModal.tsx
+++ b/frontend/components/admin/RouteFormModal.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { fetchDrivers, createRoute, updateRoute } from '@/utils/apiAdapter';
+
+interface Props {
+  date: string;
+  route?: { id: string; driverId?: string | null; name: string };
+  onClose: () => void;
+}
+
+export default function RouteFormModal({ date, route, onClose }: Props) {
+  const { data: drivers, isLoading, isError } = useQuery({
+    queryKey: ['drivers'],
+    queryFn: fetchDrivers,
+  });
+  const [driverId, setDriverId] = React.useState(route?.driverId || '');
+  const [name, setName] = React.useState(route?.name || '');
+  const qc = useQueryClient();
+  const mutation = useMutation({
+    mutationFn: () =>
+      route
+        ? updateRoute(route.id, {
+            driver_id: Number(driverId),
+            name: name || undefined,
+          })
+        : createRoute({
+            driver_id: Number(driverId),
+            route_date: date,
+            name: name || undefined,
+          }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['routes', date] });
+      onClose();
+    },
+  });
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        background: 'rgba(0,0,0,0.3)',
+      }}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="route-form-title"
+        tabIndex={-1}
+        style={{ background: '#fff', padding: 16, maxWidth: 320, margin: '10% auto' }}
+      >
+        <h3 id="route-form-title">{route ? 'Edit route' : 'Create route'}</h3>
+        {isLoading && <div role="status">Loading...</div>}
+        {isError && <div role="alert">Failed to load</div>}
+        {!isLoading && !isError && (
+          <>
+            <label>
+              <span>Driver</span>
+              <select value={driverId} onChange={(e) => setDriverId(e.target.value)}>
+                <option value="">Select driver</option>
+                {drivers?.map((d) => (
+                  <option key={d.id} value={d.id}>
+                    {d.name || d.id}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label style={{ display: 'block', marginTop: 8 }}>
+              <span>Name</span>
+              <input value={name} onChange={(e) => setName(e.target.value)} />
+            </label>
+          </>
+        )}
+        <div style={{ marginTop: 16 }}>
+          <button onClick={() => mutation.mutate()} disabled={!driverId || mutation.isLoading}>
+            {route ? 'Save' : 'Create'}
+          </button>{' '}
+          <button onClick={onClose}>Cancel</button>
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/frontend/pages/admin/routes.tsx
+++ b/frontend/pages/admin/routes.tsx
@@ -7,8 +7,17 @@ import { getOrderBadges } from '@/utils/orderBadges';
 import AdminLayout from '@/components/admin/AdminLayout';
 
 const RouteDetailDrawer = dynamic(() => import('@/components/admin/RouteDetailDrawer'));
+const RouteFormModal = dynamic(() => import('@/components/admin/RouteFormModal'));
 
-export function RouteCard({ route, onSelect }: { route: Route; onSelect: (r: Route) => void }) {
+export function RouteCard({
+  route,
+  onSelect,
+  onEdit,
+}: {
+  route: Route;
+  onSelect: (r: Route) => void;
+  onEdit: (r: Route) => void;
+}) {
   const onKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter' || e.key === ' ') {
       e.preventDefault();
@@ -26,6 +35,14 @@ export function RouteCard({ route, onSelect }: { route: Route; onSelect: (r: Rou
       <h2 style={{ marginTop: 0 }}>{route.name}</h2>
       <div>Driver: {route.driverId || '-'}</div>
       <div>Stops: {route.stops.length}</div>
+      <button
+        onClick={(e) => {
+          e.stopPropagation();
+          onEdit(route);
+        }}
+      >
+        Edit
+      </button>
     </article>
   );
 }
@@ -70,6 +87,8 @@ export default function AdminRoutesPage() {
   }, [unassigned, date]);
 
   const [selectedRoute, setSelectedRoute] = React.useState<Route | null>(null);
+  const [creating, setCreating] = React.useState(false);
+  const [editingRoute, setEditingRoute] = React.useState<Route | null>(null);
 
   return (
     <div style={{ padding: 16 }}>
@@ -83,6 +102,7 @@ export default function AdminRoutesPage() {
             onChange={(e) => router.push({ pathname: '/admin/routes', query: { date: e.target.value } })}
           />
         </label>
+        <button onClick={() => setCreating(true)}>Create Route</button>
         <span aria-live="polite">
           Routes: {routes.length} Unassigned: {unassigned.length} (No date: {counts.noDate} Overdue: {counts.overdue}) On Hold: {onHold.length}
         </span>
@@ -94,13 +114,26 @@ export default function AdminRoutesPage() {
         {!routesQuery.isLoading && routes.length > 0 && (
           <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill,minmax(220px,1fr))', gap: 8 }}>
             {routes.map((r) => (
-              <RouteCard key={r.id} route={r} onSelect={setSelectedRoute} />
+              <RouteCard
+                key={r.id}
+                route={r}
+                onSelect={setSelectedRoute}
+                onEdit={setEditingRoute}
+              />
             ))}
           </div>
         )}
       </div>
       {selectedRoute && (
         <RouteDetailDrawer route={selectedRoute} onClose={() => setSelectedRoute(null)} />
+      )}
+      {creating && <RouteFormModal date={date} onClose={() => setCreating(false)} />}
+      {editingRoute && (
+        <RouteFormModal
+          date={date}
+          route={editingRoute}
+          onClose={() => setEditingRoute(null)}
+        />
       )}
     </div>
   );

--- a/frontend/utils/api.ts
+++ b/frontend/utils/api.ts
@@ -306,6 +306,13 @@ export function createRoute(body: { driver_id: number; route_date: string; name?
   return request<any>('/routes', { json: body });
 }
 
+export function updateRoute(
+  routeId: number,
+  body: { driver_id?: number; route_date?: string; name?: string; notes?: string },
+) {
+  return request<any>(`/routes/${routeId}`, { method: 'PATCH', json: body });
+}
+
 export function listRoutes(date?: string) {
   const qs = date ? `?date=${encodeURIComponent(date)}` : '';
   return request<any[]>(`/routes${qs}`);

--- a/frontend/utils/apiAdapter.ts
+++ b/frontend/utils/apiAdapter.ts
@@ -1,4 +1,11 @@
-import { listRoutes, listOrders, addOrdersToRoute, createRoute as apiCreateRoute } from './api';
+import {
+  listRoutes,
+  listOrders,
+  addOrdersToRoute,
+  createRoute as apiCreateRoute,
+  updateRoute as apiUpdateRoute,
+  listDrivers,
+} from './api';
 
 export type Order = {
   id: string;
@@ -31,6 +38,11 @@ export type Route = {
   etaRange?: { start?: string; end?: string };
 };
 
+export type Driver = {
+  id: string;
+  name?: string;
+};
+
 function mapOrder(o: any): Order {
   return {
     id: String(o.id ?? ''),
@@ -56,6 +68,10 @@ function mapOrder(o: any): Order {
     notes: o.notes || '',
     trip: o.trip,
   };
+}
+
+function mapDriver(d: any): Driver {
+  return { id: String(d.id ?? ''), name: d.name };
 }
 
 function mapRoute(r: any): Route {
@@ -88,6 +104,11 @@ export async function fetchRoutes(date: string): Promise<Route[]> {
   return Array.isArray(data) ? data.map(mapRoute) : [];
 }
 
+export async function fetchDrivers(): Promise<Driver[]> {
+  const data = await listDrivers();
+  return Array.isArray(data) ? data.map(mapDriver) : [];
+}
+
 export async function fetchUnassigned(date: string): Promise<Order[]> {
   const { items } = await listOrders(undefined, undefined, undefined, 500, {
     date,
@@ -115,6 +136,14 @@ export async function createRoute(payload: {
   notes?: string;
 }): Promise<Route> {
   const r = await apiCreateRoute(payload);
+  return mapRoute(r);
+}
+
+export async function updateRoute(
+  routeId: string,
+  payload: { driver_id?: number; route_date?: string; name?: string; notes?: string },
+): Promise<Route> {
+  const r = await apiUpdateRoute(Number(routeId), payload);
   return mapRoute(r);
 }
 


### PR DESCRIPTION
## Summary
- enable creating routes from admin routes page
- allow editing route driver and name with backend support
- support driver lookup for route forms

## Testing
- `cd frontend && npm test`
- `cd backend && pytest`


------
https://chatgpt.com/codex/tasks/task_b_68ae505136ec832e94fb7dc7ae0a5ae7