### PR TITLE
fix: update mutation loading prop

### DIFF
--- a/frontend/components/admin/RouteFormModal.tsx
+++ b/frontend/components/admin/RouteFormModal.tsx
@@ -74,7 +74,7 @@ export default function RouteFormModal({ date, route, onClose }: Props) {
           </>
         )}
         <div style={{ marginTop: 16 }}>
-          <button onClick={() => mutation.mutate()} disabled={!driverId || mutation.isLoading}>
+          <button onClick={() => mutation.mutate()} disabled={!driverId || mutation.isPending}>
             {route ? 'Save' : 'Create'}
           </button>{' '}
           <button onClick={onClose}>Cancel</button>


### PR DESCRIPTION
## Summary
- replace deprecated `isLoading` with `isPending` on route form mutation

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68ae58f198bc832eb3a065da88b73ec5