### PR TITLE
feat: filter driver orders with commission

### DIFF
--- a/frontend/__tests__/api.test.ts
+++ b/frontend/__tests__/api.test.ts
@@ -4,6 +4,7 @@ import {
   listDrivers,
   assignOrderToDriver,
   listDriverCommissions,
+  listDriverOrders,
 } from '@/utils/api';
 
 // Use Vitest's vi to mock fetch
@@ -106,6 +107,22 @@ describe('api request unwrapping', () => {
     expect(result).toEqual(data);
     expect((global as any).fetch).toHaveBeenCalledWith(
       expect.stringContaining('/drivers/1/commissions'),
+      expect.any(Object)
+    );
+  });
+
+  it('fetches driver orders', async () => {
+    const data = [{ id: 1 }];
+    (global as any).fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      text: async () => JSON.stringify({ items: data }),
+      headers: { get: () => 'application/json' },
+    });
+
+    const result = await listDriverOrders(1, '2024-01');
+    expect(result).toEqual(data);
+    expect((global as any).fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/orders?'),
       expect.any(Object)
     );
   });

--- a/frontend/pages/admin/driver-commissions.tsx
+++ b/frontend/pages/admin/driver-commissions.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import Image from 'next/image';
 import AdminLayout from '@/components/admin/AdminLayout';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { listDrivers, listDriverCommissions, addPayment, markSuccess, updateCommission } from '@/utils/api';
+import { listDrivers, listDriverOrders, addPayment, markSuccess, updateCommission } from '@/utils/api';
 import StatusBadge from '@/components/StatusBadge';
 
 export default function DriverCommissionsPage() {
@@ -15,8 +15,8 @@ export default function DriverCommissionsPage() {
     queryFn: listDrivers,
   });
   const rowsQuery = useQuery({
-    queryKey: ['commissions', driverId, month],
-    queryFn: () => (driverId ? listDriverCommissions(Number(driverId)) : Promise.resolve([])),
+    queryKey: ['driver-orders', driverId, month],
+    queryFn: () => (driverId ? listDriverOrders(Number(driverId), month) : Promise.resolve([])),
     enabled: !!driverId,
   });
   const drivers = driversQuery.data || [];
@@ -36,12 +36,12 @@ export default function DriverCommissionsPage() {
       }
       await markSuccess(orderId);
     },
-    onSuccess: () => qc.invalidateQueries({ queryKey: ['commissions', driverId, month] }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['driver-orders', driverId, month] }),
   });
 
   const saveCommission = useMutation({
     mutationFn: async ({ orderId, amount }: any) => updateCommission(orderId, Number(amount)),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ['commissions', driverId, month] }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['driver-orders', driverId, month] }),
   });
 
   return (

--- a/frontend/utils/api.ts
+++ b/frontend/utils/api.ts
@@ -334,3 +334,12 @@ export function createDriver(payload: {
 export function listDriverCommissions(driverId: number) {
   return request<any[]>(`/drivers/${driverId}/commissions`);
 }
+
+export async function listDriverOrders(driverId: number, month?: string, limit = 500) {
+  const sp = new URLSearchParams({ driver_id: String(driverId), limit: String(limit) });
+  if (month) sp.set('month', month);
+  const data = await request<any>(`/orders?${sp.toString()}`);
+  if (Array.isArray(data)) return data;
+  if (data && typeof data === 'object' && Array.isArray(data.items)) return data.items;
+  return [];
+}


### PR DESCRIPTION
## Summary
- support driver and month filters with commission details in orders list endpoint
- add listDriverOrders API helper and use it in driver commissions admin page
- test driver order fetcher

## Testing
- `black --check .` *(fails: would reformat many files)*
- `flake8 .` *(fails: E302/E501 etc.)*
- `mypy .` *(fails: missing stubs)*
- `pytest --cov=app` *(fails: 3 tests failed)*
- `npm run lint`
- `npx tsc --noEmit` *(fails: Property 'onEdit' is missing ...)*
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68aea56d0a98832e8cefd417a492f4f2