### PR TITLE
Show driver names and order status

### DIFF
--- a/frontend/__tests__/route-card.test.tsx
+++ b/frontend/__tests__/route-card.test.tsx
@@ -8,7 +8,7 @@ describe('RouteCard', () => {
   it('calls onSelect with keyboard', async () => {
     const route: any = { id: '1', name: 'Route A', driverId: '', stops: [] };
     const onSelect = vi.fn();
-    render(<RouteCard route={route} onSelect={onSelect} />);
+    render(<RouteCard route={route} onSelect={onSelect} onEdit={() => {}} />);
     const card = screen.getByRole('button', { name: /route a/i });
     card.focus();
     const user = userEvent.setup();
@@ -16,5 +16,11 @@ describe('RouteCard', () => {
     card.focus();
     await user.keyboard(' ');
     expect(onSelect).toHaveBeenCalledTimes(2);
+  });
+
+  it('shows driver name when provided', () => {
+    const route: any = { id: '1', name: 'Route A', driverId: '1', stops: [] };
+    render(<RouteCard route={route} onSelect={() => {}} onEdit={() => {}} driverName="Alice" />);
+    expect(screen.getByText(/driver: alice/i)).toBeInTheDocument();
   });
 });

--- a/frontend/__tests__/route-detail-drawer.test.tsx
+++ b/frontend/__tests__/route-detail-drawer.test.tsx
@@ -43,6 +43,8 @@ describe('RouteDetailDrawer', () => {
     const route = { id: '1', name: 'Route A', date: '2024-07-01' } as any;
     render(<RouteDetailDrawer route={route} onClose={() => {}} />);
     expect(screen.getByText('ORD1')).toBeInTheDocument();
+    expect(screen.getByText('Status')).toBeInTheDocument();
+    expect(screen.getByText('ASSIGNED')).toBeInTheDocument();
   });
 
   it('allows selecting unassigned orders', () => {

--- a/frontend/components/admin/RouteDetailDrawer.tsx
+++ b/frontend/components/admin/RouteDetailDrawer.tsx
@@ -172,17 +172,17 @@ export default function RouteDetailDrawer({ route, onClose }: Props) {
       <h3>Stops</h3>
       <table className="table">
         <thead>
-          <tr><th>Seq</th><th>Order</th><th></th></tr>
+          <tr><th>Seq</th><th>Order</th><th>Status</th><th></th></tr>
         </thead>
         <tbody>
           {assignedQuery.isLoading && (
             <tr>
-              <td colSpan={3} role="status">Loading...</td>
+              <td colSpan={4} role="status">Loading...</td>
             </tr>
           )}
           {assignedQuery.isError && (
             <tr>
-              <td colSpan={3} role="alert">Failed to load</td>
+              <td colSpan={4} role="alert">Failed to load</td>
             </tr>
           )}
           {!assignedQuery.isLoading &&
@@ -190,13 +190,14 @@ export default function RouteDetailDrawer({ route, onClose }: Props) {
               <tr key={o.id}>
                 <td>{idx + 1}</td>
                 <td>{o.orderNo}</td>
+                <td>{o.status}</td>
                 <td>
                   <button onClick={() => removeMutation.mutate(o.id)}>Remove</button>
                 </td>
               </tr>
             ))}
           {!assignedQuery.isLoading && (assignedQuery.data?.length || 0) === 0 && (
-            <tr><td colSpan={3} style={{ opacity: 0.6 }}>No stops</td></tr>
+            <tr><td colSpan={4} style={{ opacity: 0.6 }}>No stops</td></tr>
           )}
         </tbody>
       </table>

--- a/frontend/pages/admin/routes.tsx
+++ b/frontend/pages/admin/routes.tsx
@@ -2,7 +2,13 @@ import React from 'react';
 import { useRouter } from 'next/router';
 import dynamic from 'next/dynamic';
 import { useQuery } from '@tanstack/react-query';
-import { fetchRoutes, fetchUnassigned, fetchOnHold, Route } from '@/utils/apiAdapter';
+import {
+  fetchRoutes,
+  fetchUnassigned,
+  fetchOnHold,
+  fetchDrivers,
+  Route,
+} from '@/utils/apiAdapter';
 import { getOrderBadges } from '@/utils/orderBadges';
 import AdminLayout from '@/components/admin/AdminLayout';
 
@@ -13,10 +19,12 @@ export function RouteCard({
   route,
   onSelect,
   onEdit,
+  driverName,
 }: {
   route: Route;
   onSelect: (r: Route) => void;
   onEdit: (r: Route) => void;
+  driverName?: string;
 }) {
   const onKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter' || e.key === ' ') {
@@ -33,7 +41,7 @@ export function RouteCard({
       style={{ border: '1px solid #ccc', padding: 8, cursor: 'pointer' }}
     >
       <h2 style={{ marginTop: 0 }}>{route.name}</h2>
-      <div>Driver: {route.driverId || '-'}</div>
+      <div>Driver: {driverName || '-'}</div>
       <div>Stops: {route.stops.length}</div>
       <button
         onClick={(e) => {
@@ -71,9 +79,22 @@ export default function AdminRoutesPage() {
     queryKey: ['onHold', date],
     queryFn: () => fetchOnHold(date),
   });
+  const driversQuery = useQuery({
+    queryKey: ['drivers'],
+    queryFn: fetchDrivers,
+  });
   const routes = routesQuery.data || [];
   const unassigned = unassignedQuery.data || [];
   const onHold = onHoldQuery.data || [];
+  const drivers = driversQuery.data || [];
+
+  const driverNameById = React.useMemo(() => {
+    const map: Record<string, string> = {};
+    drivers.forEach((d) => {
+      map[d.id] = d.name || '';
+    });
+    return map;
+  }, [drivers]);
 
   const counts = React.useMemo(() => {
     let noDate = 0;
@@ -119,6 +140,7 @@ export default function AdminRoutesPage() {
                 route={r}
                 onSelect={setSelectedRoute}
                 onEdit={setEditingRoute}
+                driverName={driverNameById[r.driverId || '']}
               />
             ))}
           </div>


### PR DESCRIPTION
## Summary
- Display driver names on route cards using driver lookup
- Add order status column to Route Detail Drawer

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_68aea79ae16c832eb70b6cab80838e3b