### PR TITLE
Fix driver commissions table and finalize orders on success

### DIFF
--- a/backend/tests/test_commission_actualization.py
+++ b/backend/tests/test_commission_actualization.py
@@ -75,7 +75,9 @@ def test_commission_on_success(monkeypatch):
         db.commit()
         db.refresh(cust)
 
-        order = Order(code="O1", type="OUTRIGHT", customer_id=cust.id, total=Decimal("600"))
+        order = Order(
+            code="O1", type="OUTRIGHT", customer_id=cust.id, total=Decimal("600")
+        )
         db.add(order)
         db.commit()
         db.refresh(order)
@@ -98,10 +100,10 @@ def test_commission_on_success(monkeypatch):
         assert commission.actualized_at is not None
         assert commission.computed_amount == Decimal("30.00")
         assert commission.actualization_reason == "manual_success"
+        refreshed = db.get(Order, order.id)
+        assert refreshed.status == "COMPLETED"
 
-    resp = client.patch(
-        f"/orders/{order.id}/commission", json={"amount": 40}
-    )
+    resp = client.patch(f"/orders/{order.id}/commission", json={"amount": 40})
     assert resp.status_code == 200
 
     with SessionLocal() as db:

--- a/frontend/__tests__/api.test.ts
+++ b/frontend/__tests__/api.test.ts
@@ -4,7 +4,6 @@ import {
   listDrivers,
   assignOrderToDriver,
   listDriverCommissions,
-  listDriverOrders,
 } from '@/utils/api';
 
 // Use Vitest's vi to mock fetch
@@ -111,19 +110,4 @@ describe('api request unwrapping', () => {
     );
   });
 
-  it('fetches driver orders', async () => {
-    const data = [{ id: 1 }];
-    (global as any).fetch = vi.fn().mockResolvedValue({
-      ok: true,
-      text: async () => JSON.stringify({ items: data }),
-      headers: { get: () => 'application/json' },
-    });
-
-    const result = await listDriverOrders(1, '2024-01');
-    expect(result).toEqual(data);
-    expect((global as any).fetch).toHaveBeenCalledWith(
-      expect.stringContaining('/orders?'),
-      expect.any(Object)
-    );
-  });
 });

--- a/frontend/__tests__/route-card.test.tsx
+++ b/frontend/__tests__/route-card.test.tsx
@@ -8,7 +8,8 @@ describe('RouteCard', () => {
   it('calls onSelect with keyboard', async () => {
     const route: any = { id: '1', name: 'Route A', driverId: '', stops: [] };
     const onSelect = vi.fn();
-    render(<RouteCard route={route} onSelect={onSelect} />);
+    const onEdit = vi.fn();
+    render(<RouteCard route={route} onSelect={onSelect} onEdit={onEdit} />);
     const card = screen.getByRole('button', { name: /route a/i });
     card.focus();
     const user = userEvent.setup();

--- a/frontend/utils/api.ts
+++ b/frontend/utils/api.ts
@@ -334,12 +334,3 @@ export function createDriver(payload: {
 export function listDriverCommissions(driverId: number) {
   return request<any[]>(`/drivers/${driverId}/commissions`);
 }
-
-export async function listDriverOrders(driverId: number, month?: string, limit = 500) {
-  const sp = new URLSearchParams({ driver_id: String(driverId), limit: String(limit) });
-  if (month) sp.set('month', month);
-  const data = await request<any>(`/orders?${sp.toString()}`);
-  if (Array.isArray(data)) return data;
-  if (data && typeof data === 'object' && Array.isArray(data.items)) return data.items;
-  return [];
-}


### PR DESCRIPTION
## Summary
- show driver commission orders by filtering full order list and display monthly total
- mark success also completes the order record
- adjust tests for updated APIs and component props

## Testing
- `black --check app/routers/orders.py tests/test_commission_actualization.py`
- `flake8 --max-line-length=120 --ignore=E402,W503 app/routers/orders.py tests/test_commission_actualization.py`
- `mypy app/routers/orders.py tests/test_commission_actualization.py` *(fails: many existing type errors in repository)*
- `pytest --cov=app tests/test_commission_actualization.py`
- `npm run lint`
- `npx tsc --noEmit`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68aea9ebc1c8832eaa70dba44994dc76