### PR TITLE
fix: make invoice print page full screen

### DIFF
--- a/frontend/app/invoice/[id]/print/page.tsx
+++ b/frontend/app/invoice/[id]/print/page.tsx
@@ -10,7 +10,7 @@ export default function InvoicePrintPage() {
   return (
     <iframe
       src={`/_api/orders/${id}/invoice.pdf`}
-      className="w-full h-screen"
+      className="fixed inset-0 w-screen h-screen border-0"
     />
   );
 }


### PR DESCRIPTION
## Summary
- display invoice print view full screen

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68aebbaceb0c832ebb6d696a3ff2ddf9