### PR TITLE
Fix route order filtering and remove bogus stop count

### DIFF
--- a/frontend/__tests__/apiAdapter.test.ts
+++ b/frontend/__tests__/apiAdapter.test.ts
@@ -64,9 +64,12 @@ describe('apiAdapter', () => {
       ],
     });
     const orders = await fetchRouteOrders('1', '2024-05-25');
-    expect(api.listOrders).toHaveBeenCalledWith(undefined, undefined, undefined, 500, {
-      date: '2024-05-25',
-    });
+    expect(api.listOrders).toHaveBeenCalledWith(
+      undefined,
+      undefined,
+      undefined,
+      500,
+    );
     expect(orders).toHaveLength(1);
     expect(orders[0].routeId).toBe('1');
   });

--- a/frontend/pages/admin/routes.tsx
+++ b/frontend/pages/admin/routes.tsx
@@ -42,7 +42,7 @@ export function RouteCard({
     >
       <h2 style={{ marginTop: 0 }}>{route.name}</h2>
       <div>Driver: {driverName || '-'}</div>
-      <div>Stops: {route.stops.length}</div>
+      <div>Stops: —</div>
       <button
         onClick={(e) => {
           e.stopPropagation();

--- a/frontend/utils/apiAdapter.ts
+++ b/frontend/utils/apiAdapter.ts
@@ -122,8 +122,11 @@ export async function fetchOnHold(date: string): Promise<Order[]> {
   return (items || []).map(mapOrder);
 }
 
-export async function fetchRouteOrders(routeId: string, date: string): Promise<Order[]> {
-  const { items } = await listOrders(undefined, undefined, undefined, 500, { date });
+export async function fetchRouteOrders(
+  routeId: string,
+  _date: string,
+): Promise<Order[]> {
+  const { items } = await listOrders(undefined, undefined, undefined, 500);
   return (items || [])
     .filter((o: any) => o.trip?.route_id === Number(routeId))
     .map(mapOrder);


### PR DESCRIPTION
## Summary
- fetch route orders without date filter so newly assigned orders remain visible
- stop showing incorrect stop counts on route cards
- adjust tests for new route order retrieval behavior

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_b_68aebdbf6d58832e801181d27e451a7f