### PR TITLE
feat: improve desktop layout

### DIFF
--- a/frontend/components/Layout.tsx
+++ b/frontend/components/Layout.tsx
@@ -38,6 +38,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
   const router = useRouter();
   const [mobileOpen, setMobileOpen] = React.useState(false);
   const menuRef = React.useRef<HTMLElement>(null);
+  const headerRef = React.useRef<HTMLElement>(null);
   const { data: user, error: userErr } = useSWR('me', getMe, {
     shouldRetryOnError: false,
   });
@@ -65,6 +66,19 @@ export default function Layout({ children }: { children: React.ReactNode }) {
     }
   }, [mobileOpen]);
   React.useEffect(() => {
+    const el = headerRef.current;
+    if (!el) return;
+    const update = () =>
+      document.documentElement.style.setProperty(
+        '--app-header-h',
+        `${el.offsetHeight}px`
+      );
+    update();
+    const ro = new ResizeObserver(update);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+  React.useEffect(() => {
     function handleKey(e: KeyboardEvent) {
       if (!mobileOpen) return;
       if (e.key === 'Escape') setMobileOpen(false);
@@ -87,7 +101,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
   }, [mobileOpen]);
   return (
     <div className="layout">
-      <header className="header">
+      <header ref={headerRef} className="header">
         <div className="header-inner">
           <h1>OrderOps</h1>
           <button

--- a/frontend/components/admin/AdminNav.tsx
+++ b/frontend/components/admin/AdminNav.tsx
@@ -19,8 +19,8 @@ export default function AdminNav() {
         borderBottom: '1px solid #eee',
         background: '#fff',
         position: 'sticky',
-        top: 0,
-        zIndex: 10,
+        top: 'var(--app-header-h, 64px)',
+        zIndex: 900,
       }}
     >
       {items.map((item) => (

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -9,7 +9,8 @@
   --radius-2: 8px;
   --radius-3: 12px;
   --radius-4: 16px;
-  --container-max: 1200px;
+  --app-header-h: 64px;
+  --container-max: 1440px;
   --max-w-screen-2xl: 1536px;
   --gutter-x-sm: 1rem;
   --gutter-x-md: 1.5rem;
@@ -53,13 +54,13 @@ h6 {
 }
 
 .header-inner {
-  max-width: 80rem;
+  max-width: var(--container-max);
   margin: 0 auto;
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 16px;
-  padding: 12px 16px;
+  padding: var(--space-3) var(--space-6);
 }
 
 .nav {
@@ -278,6 +279,36 @@ h6 {
   max-width: 32rem;
   max-height: 90vh;
   overflow-y: auto;
+}
+
+@media (min-width: 1024px) {
+  .header-inner {
+    display: flex;
+    align-items: center;
+    flex-wrap: nowrap;
+    gap: 16px;
+    justify-content: flex-start;
+  }
+  .nav {
+    display: flex;
+    position: static;
+    width: auto;
+    padding: 0;
+    gap: 24px;
+    overflow-x: auto;
+    flex-wrap: nowrap;
+    margin-left: auto;
+    flex: 1;
+    min-width: 0;
+  }
+  .nav-toggle {
+    display: none;
+  }
+  .main > .container {
+    max-width: var(--container-max);
+    padding-left: var(--space-8);
+    padding-right: var(--space-8);
+  }
 }
 
 @media (max-width: 1024px) {


### PR DESCRIPTION
## Summary
- observe header height to sync CSS variable
- make admin nav offset below header
- refine desktop nav and container widths

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68aebe08a5dc832ea0bcf623a2ab8957