### PR TITLE
Ensure POD links open for driver commissions

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -6,7 +6,10 @@ const API_BASE =
 module.exports = {
   reactStrictMode: true,
   images: {
-    remotePatterns: [{ protocol: 'https', hostname: '**' }],
+    remotePatterns: [
+      { protocol: 'https', hostname: '**' },
+      { protocol: 'http', hostname: '**' },
+    ],
   },
   async rewrites() {
     // Proxy path you can use for local dev if you prefer: /_api/* -> API_BASE/*

--- a/frontend/pages/admin/driver-commissions.tsx
+++ b/frontend/pages/admin/driver-commissions.tsx
@@ -135,7 +135,9 @@ function OrderRow({ o, onPaySuccess, onSaveCommission }: { o: any; onPaySuccess:
     String(o?.trip?.commission?.computed_amount ?? o?.commission ?? '')
   );
 
-  const pod = o?.trip?.pod_photo_url || o?.pod_photo_url;
+  const apiBase = (process.env.NEXT_PUBLIC_API_URL || '').replace(/\/+$/, '');
+  let pod = o?.trip?.pod_photo_url || o?.pod_photo_url;
+  if (pod && !pod.startsWith('http')) pod = `${apiBase}${pod}`;
   const canSuccess =
     o.status === 'DELIVERED' &&
     !!pod &&


### PR DESCRIPTION
## Summary
- prefix POD image URLs with API base to produce working links
- allow http images in Next.js config so POD previews render

## Testing
- `cd frontend && npm test`
- `cd frontend && npm run lint`
- `cd backend && pytest` *(fails: no such table: commissions)*

------
https://chatgpt.com/codex/tasks/task_b_68aed6d84de0832ebe8a8584fff997f7