### PR TITLE
Fix invoice print iframe sizing

### DIFF
--- a/frontend/app/invoice/[id]/print/page.tsx
+++ b/frontend/app/invoice/[id]/print/page.tsx
@@ -10,7 +10,8 @@ export default function InvoicePrintPage() {
   return (
     <iframe
       src={`/_api/orders/${id}/invoice.pdf`}
-      className="fixed inset-0 w-screen h-screen border-0"
+      className="fixed inset-0 block w-full h-full border-0"
+      title="Invoice PDF"
     />
   );
 }


### PR DESCRIPTION
## Summary
- ensure invoice PDF fills viewport on print page

## Testing
- `npm test`
- `pytest` *(fails: OperationalError in test_orders_backlog tests)*

------
https://chatgpt.com/codex/tasks/task_b_68af1da0b83c832ea3cf4dffc15a20e2