### PR TITLE
Fix POD display by normalizing POD URLs and proxying uploads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,4 @@
 - ensure middleware excludes Next.js static/image routes
 - add POD viewer page that supports images and PDFs
 - improve driver commissions page with success messaging and tests
+- proxy /static/uploads to API and normalize POD URLs so proof-of-delivery files render

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,5 +1,6 @@
 APP_VERSION=local
 CORS_ORIGIN=http://localhost:3000
+PUBLIC_BASE_URL=http://localhost:8000
 
 # DB (local dev)
 # DATABASE_URL=postgresql+psycopg://user:pass@localhost:5432/orderops?sslmode=disable

--- a/backend/app/utils/storage.py
+++ b/backend/app/utils/storage.py
@@ -7,6 +7,7 @@ from PIL import Image, ImageOps
 MAX_SIDE = 1280
 MAX_BYTES = 5 * 1024 * 1024
 UPLOAD_DIR = os.getenv("UPLOAD_DIR", "uploads")
+PUBLIC_BASE_URL = os.getenv("PUBLIC_BASE_URL", "").rstrip("/")
 os.makedirs(UPLOAD_DIR, exist_ok=True)
 
 
@@ -22,4 +23,7 @@ def save_pod_image(file_bytes: bytes) -> str:
     path = os.path.join(UPLOAD_DIR, name)
     with open(path, "wb") as f:
         f.write(out.getvalue())
-    return f"/static/uploads/{name}"
+    url = f"/static/uploads/{name}"
+    if PUBLIC_BASE_URL:
+        url = f"{PUBLIC_BASE_URL}{url}"
+    return url

--- a/backend/tests/test_storage_public_url.py
+++ b/backend/tests/test_storage_public_url.py
@@ -1,0 +1,14 @@
+import importlib
+from io import BytesIO
+from PIL import Image
+
+def test_save_pod_image_public_url(tmp_path, monkeypatch):
+    monkeypatch.setenv('UPLOAD_DIR', str(tmp_path))
+    monkeypatch.setenv('PUBLIC_BASE_URL', 'https://api.example.com')
+    from app.utils import storage
+    importlib.reload(storage)
+    img = Image.new('RGB', (1, 1), color='white')
+    buf = BytesIO()
+    img.save(buf, format='JPEG')
+    url = storage.save_pod_image(buf.getvalue())
+    assert url.startswith('https://api.example.com/static/uploads/')

--- a/frontend/__tests__/driver-commissions-row.test.tsx
+++ b/frontend/__tests__/driver-commissions-row.test.tsx
@@ -40,4 +40,17 @@ describe('OrderRow', () => {
     expect(save).toHaveBeenCalled();
     expect(screen.getByText(/saved/i)).toBeInTheDocument();
   });
+
+  it('prefixes relative POD url with API base', () => {
+    process.env.NEXT_PUBLIC_API_URL = 'https://api.example.com';
+    const order = { ...baseOrder, trip: { pod_photo_url: '/static/uploads/x.jpg', commission: { computed_amount: 0 } } };
+    render(
+      <table>
+        <tbody>
+          <OrderRow o={order} onPaySuccess={async () => {}} onSaveCommission={async () => {}} />
+        </tbody>
+      </table>
+    );
+    expect(screen.getByRole('img', { name: /pod/i })).toHaveAttribute('src', 'https://api.example.com/static/uploads/x.jpg');
+  });
 });

--- a/frontend/__tests__/pod-url.test.ts
+++ b/frontend/__tests__/pod-url.test.ts
@@ -1,0 +1,12 @@
+import { resolvePodUrl } from '@/utils/pod';
+
+describe('resolvePodUrl', () => {
+  it('returns absolute url when env set', () => {
+    process.env.NEXT_PUBLIC_API_URL = 'https://api.example.com';
+    expect(resolvePodUrl('/static/uploads/a.jpg')).toBe('https://api.example.com/static/uploads/a.jpg');
+  });
+
+  it('returns as-is when already absolute', () => {
+    expect(resolvePodUrl('https://x.com/a.jpg')).toBe('https://x.com/a.jpg');
+  });
+});

--- a/frontend/components/PodViewer.tsx
+++ b/frontend/components/PodViewer.tsx
@@ -10,5 +10,17 @@ export default function PodViewer({ url }: { url: string }) {
       </object>
     );
   }
-  return <img src={url} alt="POD" style={{ maxWidth: '100%', height: 'auto' }} data-testid="pod-image" />;
+  return (
+    <div>
+      <img src={url} alt="POD" style={{ maxWidth: '100%', height: 'auto' }} data-testid="pod-image" />
+      <p>
+        <button
+          type="button"
+          onClick={() => window.open(url, '_blank', 'noopener,noreferrer')}
+        >
+          Open POD
+        </button>
+      </p>
+    </div>
+  );
 }

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -23,6 +23,8 @@ export function middleware(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ['/((?!api|_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt).*)'],
+  matcher: [
+    '/((?!api|_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt|static/uploads).*)',
+  ],
 };
 

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -15,6 +15,9 @@ module.exports = {
   },
   async rewrites() {
     // Proxy path you can use for local dev if you prefer: /_api/* -> API_BASE/*
-    return [{ source: "/_api/:path*", destination: `${API_BASE}/:path*` }];
+    return [
+      { source: "/_api/:path*", destination: `${API_BASE}/:path*` },
+      { source: "/static/uploads/:path*", destination: `${API_BASE}/static/uploads/:path*` },
+    ];
   },
 };

--- a/frontend/pages/admin/driver-commissions.tsx
+++ b/frontend/pages/admin/driver-commissions.tsx
@@ -4,6 +4,7 @@ import AdminLayout from '@/components/admin/AdminLayout';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { listDrivers, listDriverOrders, addPayment, markSuccess, updateCommission } from '@/utils/api';
 import StatusBadge from '@/components/StatusBadge';
+import { resolvePodUrl } from '@/utils/pod';
 
 export default function DriverCommissionsPage() {
   const qc = useQueryClient();
@@ -136,9 +137,7 @@ export function OrderRow({ o, onPaySuccess, onSaveCommission }: { o: any; onPayS
   );
   const [msg, setMsg] = React.useState('');
 
-  const apiBase = (process.env.NEXT_PUBLIC_API_URL || '').replace(/\/+$/, '');
-  let pod = o?.trip?.pod_photo_url || o?.pod_photo_url;
-  if (pod && !pod.startsWith('http')) pod = `${apiBase}${pod}`;
+  let pod = resolvePodUrl(o?.trip?.pod_photo_url || o?.pod_photo_url);
   const isPdf = pod ? /\.pdf($|\?)/i.test(pod) : false;
   const podHref = pod ? `/pod-viewer?url=${encodeURIComponent(pod)}` : '';
   const canSuccess =

--- a/frontend/pages/pod-viewer.tsx
+++ b/frontend/pages/pod-viewer.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import { useRouter } from 'next/router';
 import PodViewer from '@/components/PodViewer';
+import { resolvePodUrl } from '@/utils/pod';
 
 export default function PodViewerPage() {
   const router = useRouter();
   const { url } = router.query;
-  const src = typeof url === 'string' ? decodeURIComponent(url) : '';
+  const src = typeof url === 'string' ? resolvePodUrl(decodeURIComponent(url)) : '';
   if (!src) return <p>No POD</p>;
   return <PodViewer url={src} />;
 }

--- a/frontend/utils/pod.ts
+++ b/frontend/utils/pod.ts
@@ -1,0 +1,12 @@
+export function resolvePodUrl(url: string | undefined): string {
+  if (!url) return '';
+  if (url.startsWith('http')) return url;
+  const base = (process.env.NEXT_PUBLIC_API_URL || '').replace(/\/+$/, '');
+  if (!base) {
+    if (typeof console !== 'undefined') {
+      console.warn('NEXT_PUBLIC_API_URL not set; relying on rewrite for /static/uploads');
+    }
+    return url;
+  }
+  return `${base}${url}`;
+}


### PR DESCRIPTION
## Summary
- proxy `/static/uploads` to API and normalize POD URLs
- add POD viewer open-in-new-tab button and URL helper
- allow backend to return absolute POD URLs via `PUBLIC_BASE_URL`

## Testing
- `npm test`
- `pytest` *(fails: sqlite OperationalError in backlog tests)*

------
https://chatgpt.com/codex/tasks/task_b_68af1dfab4f8832e8a26b91180accb5b