### PR TITLE
feat: add HTML invoice template

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,2 @@
+This project includes the Sparksuite Simple HTML Invoice Template, licensed under the MIT License.
+See THIRD_PARTY/sparksuite_simple_html_invoice_template_LICENSE.txt for details.

--- a/THIRD_PARTY/sparksuite_simple_html_invoice_template_LICENSE.txt
+++ b/THIRD_PARTY/sparksuite_simple_html_invoice_template_LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 Sparksuite
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/backend/README.md
+++ b/backend/README.md
@@ -39,6 +39,12 @@ The backend also exposes `/auth/register` which allows creating an initial
 `ADMIN` account when there are no users. Disable or guard this endpoint in
 production.
 
+## Invoice Template
+
+Invoices are rendered using the [Sparksuite Simple HTML Invoice Template](https://github.com/sparksuite/simple-html-invoice-template) via WeasyPrint. The template and stylesheet live in `backend/templates/invoice/` and `backend/static/invoice/`.
+
+Set `USE_HTML_TEMPLATE_INVOICE=1` to enable this HTML-based renderer. If the environment variable is unset or WeasyPrint is unavailable, the system falls back to the legacy ReportLab implementation. Customize the layout by editing the vendored template files.
+
 ## Environment variables
 
 - `FIREBASE_SERVICE_ACCOUNT_JSON`: JSON string for Firebase service account used to verify driver ID tokens.

--- a/backend/app/services/documents.py
+++ b/backend/app/services/documents.py
@@ -1,11 +1,11 @@
-"""PDF generation utilities using ReportLab.
+"""PDF generation utilities.
 
-ReportLab is optional. To avoid import-time crashes when it's absent, we only
-import it within the functions that actually render PDFs. Each function raises a
-clear error if ReportLab is missing so callers can respond with a helpful
-message instead of the application failing to start.
+Legacy implementations use ReportLab. A new HTML-to-PDF path powered by
+WeasyPrint can be enabled with ``USE_HTML_TEMPLATE_INVOICE=1``.
 """
 
+import os
+import logging
 from io import BytesIO
 
 from ..core.config import settings
@@ -14,13 +14,154 @@ from ..models.payment import Payment
 from ..models.plan import Plan
 
 
+def build_invoice_context(order: Order) -> dict:
+    company = getattr(order, "company", None) or type("X", (), {})()
+    bank = getattr(company, "bank", None) or type("X", (), {})()
+    subtotal = float(getattr(order, "subtotal", 0) or 0)
+    discount = float(getattr(order, "discount", 0) or 0)
+    delivery_fee = float(getattr(order, "delivery_fee", 0) or 0)
+    penalty_amount = float(getattr(order, "penalty_fee", 0) or 0)
+    buyback_amount = float(getattr(order, "return_delivery_fee", 0) or 0)
+    tax_amount = float(getattr(order, "tax_total", 0) or 0)
+    total = (
+        subtotal
+        - discount
+        + delivery_fee
+        + penalty_amount
+        - buyback_amount
+        + tax_amount
+    )
+    doc_title = "CREDIT NOTE" if total < 0 else "INVOICE"
+    customer = getattr(order, "customer", None) or type("X", (), {})()
+    bill_to = {
+        "name": getattr(customer, "name", ""),
+        "address_lines": getattr(customer, "address_lines", None)
+        or (
+            [getattr(customer, "address", "")]
+            if getattr(customer, "address", "")
+            else []
+        ),
+        "phone": getattr(customer, "phone", ""),
+        "email": getattr(customer, "email", ""),
+    }
+    ship_obj = getattr(order, "shipping_to", None)
+    ship_to = None
+    if ship_obj:
+        ship_to = {
+            "name": getattr(ship_obj, "name", ""),
+            "address_lines": getattr(ship_obj, "address_lines", None)
+            or (
+                [getattr(ship_obj, "address", "")]
+                if getattr(ship_obj, "address", "")
+                else []
+            ),
+        }
+    items = []
+    for it in getattr(order, "items", []) or []:
+        items.append(
+            {
+                "description": getattr(it, "name", getattr(it, "description", ""))
+                or "",
+                "qty": float(getattr(it, "qty", 0) or 0),
+                "unit_price": float(getattr(it, "unit_price", 0) or 0),
+                "line_total": float(
+                    getattr(it, "line_total", getattr(it, "amount", 0)) or 0
+                ),
+            }
+        )
+    notes = getattr(getattr(order, "footer", None), "note", "") or ""
+    qr_url = getattr(getattr(order, "payment", None), "qrDataUrl", None)
+    context = {
+        "doc_title": doc_title,
+        "company": {
+            "name": getattr(company, "name", ""),
+            "logo_url": getattr(
+                company, "logo_url", getattr(settings, "COMPANY_LOGO_URL", "")
+            ),
+            "reg_no": getattr(company, "reg_no", ""),
+            "tax_label": getattr(company, "tax_label", "Tax"),
+            "tax_percent": getattr(company, "tax_percent", ""),
+            "address_lines": getattr(company, "address_lines", None)
+            or (
+                [getattr(settings, "COMPANY_ADDRESS", "")]
+                if getattr(settings, "COMPANY_ADDRESS", "")
+                else []
+            ),
+            "phone": getattr(company, "phone", getattr(settings, "COMPANY_PHONE", "")),
+            "email": getattr(company, "email", getattr(settings, "COMPANY_EMAIL", "")),
+            "bank": {
+                "name": getattr(bank, "name", ""),
+                "acct_no": getattr(bank, "acct_no", ""),
+                "beneficiary": getattr(bank, "beneficiary", ""),
+                "iban": getattr(bank, "iban", ""),
+                "swift": getattr(bank, "swift", ""),
+            },
+        },
+        "invoice": {
+            "number": getattr(order, "code", ""),
+            "date": getattr(order, "created_at", "") or "",
+            "due_date": getattr(order, "due_date", "") or "",
+        },
+        "bill_to": bill_to,
+        "ship_to": ship_to,
+        "items": items,
+        "summary": {
+            "subtotal": subtotal,
+            "discount": discount,
+            "delivery_fee": delivery_fee,
+            "penalty_amount": penalty_amount,
+            "buyback_amount": buyback_amount,
+            "tax_amount": tax_amount,
+            "total": total,
+        },
+        "notes": notes,
+        "qr_url": qr_url,
+        "rtl": getattr(order, "rtl", False),
+    }
+    return context
+
+
 def invoice_pdf(order: Order) -> bytes:
-    """Render an invoice using a Fortune 500 style template."""
+    """Render an invoice as PDF, using WeasyPrint when enabled."""
+    use_html = os.getenv("USE_HTML_TEMPLATE_INVOICE") == "1"
+    if use_html:
+        try:
+            from jinja2 import Environment, FileSystemLoader, select_autoescape
+            from weasyprint import HTML, CSS
+
+            ctx = build_invoice_context(order)
+            env = Environment(
+                loader=FileSystemLoader("backend/templates"),
+                autoescape=select_autoescape(["html"]),
+            )
+            tmpl = env.get_template("invoice/invoice.html")
+            html = tmpl.render(**ctx)
+            return HTML(string=html, base_url="backend/").write_pdf(
+                stylesheets=[CSS("backend/static/invoice/invoice.css")]
+            )
+        except Exception:
+            logging.exception(
+                "HTML invoice generation failed; falling back to ReportLab"
+            )
+    return legacy_reportlab_invoice_pdf(order)
+
+
+def legacy_reportlab_invoice_pdf(order: Order) -> bytes:
+    """Render an invoice using the original ReportLab template."""
     try:  # pragma: no cover - exercised indirectly in tests
         from reportlab.lib.pagesizes import A4
         from reportlab.lib.units import mm
         from reportlab.lib import colors
-        from reportlab.platypus import SimpleDocTemplate, Paragraph, Spacer, Table, TableStyle, Image, KeepTogether, PageBreak
+        from reportlab.platypus import (
+            SimpleDocTemplate,
+            Paragraph,
+            Spacer,
+            Table,
+            TableStyle,
+            Image,
+            KeepTogether,
+            PageBreak,
+        )
         from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
         from reportlab.lib.enums import TA_RIGHT
         from reportlab.pdfbase import pdfmetrics
@@ -32,7 +173,9 @@ def invoice_pdf(order: Order) -> bytes:
 
     try:
         pdfmetrics.registerFont(TTFont("Inter", "/app/static/fonts/Inter-Regular.ttf"))
-        pdfmetrics.registerFont(TTFont("Inter-Bold", "/app/static/fonts/Inter-Bold.ttf"))
+        pdfmetrics.registerFont(
+            TTFont("Inter-Bold", "/app/static/fonts/Inter-Bold.ttf")
+        )
         BASE_FONT = "Inter"
         BASE_BOLD = "Inter-Bold"
     except Exception:
@@ -42,33 +185,65 @@ def invoice_pdf(order: Order) -> bytes:
     styles = getSampleStyleSheet()
     styles["Normal"].fontName = BASE_FONT
     styles["Title"].fontName = BASE_BOLD
-    styles.add(ParagraphStyle(name="Small", parent=styles["Normal"], fontSize=9, leading=11))
-    styles.add(ParagraphStyle(name="Right", parent=styles["Normal"], alignment=TA_RIGHT))
+    styles.add(
+        ParagraphStyle(name="Small", parent=styles["Normal"], fontSize=9, leading=11)
+    )
+    styles.add(
+        ParagraphStyle(name="Right", parent=styles["Normal"], alignment=TA_RIGHT)
+    )
     styles.add(ParagraphStyle(name="Note", parent=styles["Small"], textColor="#555555"))
 
     buf = BytesIO()
-    doc = SimpleDocTemplate(buf, pagesize=A4, leftMargin=20*mm, rightMargin=20*mm, topMargin=20*mm, bottomMargin=20*mm)
+    doc = SimpleDocTemplate(
+        buf,
+        pagesize=A4,
+        leftMargin=20 * mm,
+        rightMargin=20 * mm,
+        topMargin=20 * mm,
+        bottomMargin=20 * mm,
+    )
     elems = []
 
-    brand_color = getattr(getattr(order, "company", None), "brand_color", None) or "#000000"
+    brand_color = (
+        getattr(getattr(order, "company", None), "brand_color", None) or "#000000"
+    )
     logo_path = getattr(settings, "COMPANY_LOGO_PATH", None)
     from reportlab.lib.colors import HexColor
+
     BAR_H = 18  # points
 
     def _page_deco(c, d):
         c.saveState()
         c.setFillColor(HexColor(brand_color))
-        c.rect(0, d.height + d.topMargin + d.bottomMargin - BAR_H, d.width + d.leftMargin + d.rightMargin, BAR_H, fill=1, stroke=0)
+        c.rect(
+            0,
+            d.height + d.topMargin + d.bottomMargin - BAR_H,
+            d.width + d.leftMargin + d.rightMargin,
+            BAR_H,
+            fill=1,
+            stroke=0,
+        )
         if logo_path:
             try:
-                c.drawImage(logo_path, d.leftMargin, d.height + d.topMargin + d.bottomMargin - BAR_H + 2, height=BAR_H-4, preserveAspectRatio=True, mask='auto')
+                c.drawImage(
+                    logo_path,
+                    d.leftMargin,
+                    d.height + d.topMargin + d.bottomMargin - BAR_H + 2,
+                    height=BAR_H - 4,
+                    preserveAspectRatio=True,
+                    mask="auto",
+                )
             except Exception:
                 pass
         c.setFont(BASE_BOLD, 10)
-        c.setFillColorRGB(1,1,1)
-        c.drawRightString(d.width + d.leftMargin, d.height + d.topMargin + d.bottomMargin - BAR_H + 5, getattr(settings, "COMPANY_NAME", ""))
+        c.setFillColorRGB(1, 1, 1)
+        c.drawRightString(
+            d.width + d.leftMargin,
+            d.height + d.topMargin + d.bottomMargin - BAR_H + 5,
+            getattr(settings, "COMPANY_NAME", ""),
+        )
         c.setFont(BASE_FONT, 9)
-        c.setFillColorRGB(0,0,0)
+        c.setFillColorRGB(0, 0, 0)
         c.drawRightString(d.width + d.leftMargin, 15, f"Page {d.page}")
         c.restoreState()
 
@@ -79,13 +254,20 @@ def invoice_pdf(order: Order) -> bytes:
         Paragraph(getattr(settings, "COMPANY_ADDRESS", ""), styles["Small"]),
         Spacer(1, 6),
         Paragraph(f"{title} {getattr(order,'code','')}", styles["Heading2"]),
-        Paragraph(f"Issue Date: {getattr(inv_date,'strftime',lambda *_: '')('%Y-%m-%d')}", styles["Normal"]),
+        Paragraph(
+            f"Issue Date: {getattr(inv_date,'strftime',lambda *_: '')('%Y-%m-%d')}",
+            styles["Normal"],
+        ),
         Spacer(1, 8),
     ]
     meta_rows = []
+
     def add(k, v):
         if v:
-            meta_rows.append([Paragraph(k, styles["Small"]), Paragraph(str(v), styles["Right"])])
+            meta_rows.append(
+                [Paragraph(k, styles["Small"]), Paragraph(str(v), styles["Right"])]
+            )
+
     add("Due Date", getattr(order, "due_date", None))
     add("PO", getattr(order, "po_number", None))
     add("Ref", getattr(order, "reference", None))
@@ -93,104 +275,174 @@ def invoice_pdf(order: Order) -> bytes:
     if tax_id:
         add("Tax ID", tax_id)
     if meta_rows:
-        t = Table(meta_rows, colWidths=[40*mm, 60*mm])
-        t.setStyle(TableStyle([("ALIGN",(1,0),(-1,-1),"RIGHT")]))
-        elems += [t, Spacer(1,8)]
+        t = Table(meta_rows, colWidths=[40 * mm, 60 * mm])
+        t.setStyle(TableStyle([("ALIGN", (1, 0), (-1, -1), "RIGHT")]))
+        elems += [t, Spacer(1, 8)]
 
     def block(label, obj):
-        lines = [f"<b>{label}</b>", getattr(obj,"name", "") or ""]
-        attn = getattr(obj,"attn", None)
+        lines = [f"<b>{label}</b>", getattr(obj, "name", "") or ""]
+        attn = getattr(obj, "attn", None)
         if attn:
             lines.append(f"Attn: {attn}")
-        addr = getattr(obj,"address", None)
+        addr = getattr(obj, "address", None)
         if addr:
             lines.append(addr)
-        email = getattr(obj,"email", None)
+        email = getattr(obj, "email", None)
         if email:
             lines.append(email)
         return Paragraph("<br/>".join(lines), styles["Normal"])
-    bill = block("Bill To", getattr(order, "customer", None) or type("X",(),{})())
-    ship_to = getattr(order, "shipping_to", None)
-    bill_ship = [ [bill, block("Ship To", ship_to)] ] if ship_to else [ [bill] ]
-    bt = Table(bill_ship, colWidths=[90*mm, 90*mm] if ship_to else [180*mm])
-    bt.setStyle(TableStyle([("BOX",(0,0),(-1,-1),0.5,colors.grey), ("INNERGRID",(0,0),(-1,-1),0.5,colors.grey), ("LEFTPADDING",(0,0),(-1,-1),6), ("RIGHTPADDING",(0,0),(-1,-1),6), ("TOPPADDING",(0,0),(-1,-1),4), ("BOTTOMPADDING",(0,0),(-1,-1),4)]))
-    elems += [bt, Spacer(1,8)]
 
-    header = ["SKU","Description","Qty","Unit","Unit Price","Disc","Tax","Amount"]
+    bill = block("Bill To", getattr(order, "customer", None) or type("X", (), {})())
+    ship_to = getattr(order, "shipping_to", None)
+    bill_ship = [[bill, block("Ship To", ship_to)]] if ship_to else [[bill]]
+    bt = Table(bill_ship, colWidths=[90 * mm, 90 * mm] if ship_to else [180 * mm])
+    bt.setStyle(
+        TableStyle(
+            [
+                ("BOX", (0, 0), (-1, -1), 0.5, colors.grey),
+                ("INNERGRID", (0, 0), (-1, -1), 0.5, colors.grey),
+                ("LEFTPADDING", (0, 0), (-1, -1), 6),
+                ("RIGHTPADDING", (0, 0), (-1, -1), 6),
+                ("TOPPADDING", (0, 0), (-1, -1), 4),
+                ("BOTTOMPADDING", (0, 0), (-1, -1), 4),
+            ]
+        )
+    )
+    elems += [bt, Spacer(1, 8)]
+
+    header = [
+        "SKU",
+        "Description",
+        "Qty",
+        "Unit",
+        "Unit Price",
+        "Disc",
+        "Tax",
+        "Amount",
+    ]
     data = [header]
-    for it in getattr(order,"items",[]) or []:
-        sku = getattr(it,"sku", "") or ""
-        name = getattr(it,"name","") or ""
-        note = getattr(it,"note","") or ""
-        qty = int(getattr(it,"qty",0) or 0)
-        unit = getattr(it,"unit","") or "-"
-        unit_price = float(getattr(it,"unit_price",0) or 0)
-        disc = getattr(it,"discount_rate", None)
-        taxr = getattr(it,"tax_rate", None)
+    for it in getattr(order, "items", []) or []:
+        sku = getattr(it, "sku", "") or ""
+        name = getattr(it, "name", "") or ""
+        note = getattr(it, "note", "") or ""
+        qty = int(getattr(it, "qty", 0) or 0)
+        unit = getattr(it, "unit", "") or "-"
+        unit_price = float(getattr(it, "unit_price", 0) or 0)
+        disc = getattr(it, "discount_rate", None)
+        taxr = getattr(it, "tax_rate", None)
         discounted = unit_price * (1 - (disc or 0))
         amount = discounted * qty
-        data.append([
-            sku,
-            Paragraph(name + (f"<br/><font color='#555555' size='9'>{note}</font>" if note else ""), styles["Normal"]),
-            f"{qty}",
-            unit,
-            f"RM{unit_price:,.2f}",
-            (f"{disc*100:.0f}%" if disc else "-"),
-            (f"{taxr*100:.0f}%" if taxr else "-"),
-            f"RM{amount:,.2f}",
-        ])
-    colw = [20*mm, 70*mm, 15*mm, 15*mm, 25*mm, 15*mm, 15*mm, 25*mm]
+        data.append(
+            [
+                sku,
+                Paragraph(
+                    name
+                    + (
+                        f"<br/><font color='#555555' size='9'>{note}</font>"
+                        if note
+                        else ""
+                    ),
+                    styles["Normal"],
+                ),
+                f"{qty}",
+                unit,
+                f"RM{unit_price:,.2f}",
+                (f"{disc*100:.0f}%" if disc else "-"),
+                (f"{taxr*100:.0f}%" if taxr else "-"),
+                f"RM{amount:,.2f}",
+            ]
+        )
+    colw = [20 * mm, 70 * mm, 15 * mm, 15 * mm, 25 * mm, 15 * mm, 15 * mm, 25 * mm]
     itab = Table(data, colWidths=colw, repeatRows=1)
-    itab.setStyle(TableStyle([
-        ("BACKGROUND",(0,0),(-1,0),colors.whitesmoke),
-        ("FONTNAME",(0,0),(-1,0),BASE_BOLD),
-        ("GRID",(0,0),(-1,-1),0.25,colors.grey),
-        ("ALIGN",(2,1),(-1,-1),"RIGHT"),
-        ("LEFTPADDING",(0,0),(-1,-1),6),
-        ("RIGHTPADDING",(0,0),(-1,-1),6),
-        ("TOPPADDING",(0,0),(-1,-1),4),
-        ("BOTTOMPADDING",(0,0),(-1,-1),4),
-    ]))
-    elems += [itab, Spacer(1,10)]
+    itab.setStyle(
+        TableStyle(
+            [
+                ("BACKGROUND", (0, 0), (-1, 0), colors.whitesmoke),
+                ("FONTNAME", (0, 0), (-1, 0), BASE_BOLD),
+                ("GRID", (0, 0), (-1, -1), 0.25, colors.grey),
+                ("ALIGN", (2, 1), (-1, -1), "RIGHT"),
+                ("LEFTPADDING", (0, 0), (-1, -1), 6),
+                ("RIGHTPADDING", (0, 0), (-1, -1), 6),
+                ("TOPPADDING", (0, 0), (-1, -1), 4),
+                ("BOTTOMPADDING", (0, 0), (-1, -1), 4),
+            ]
+        )
+    )
+    elems += [itab, Spacer(1, 10)]
 
-    def row(k,v): return [Paragraph(k, styles["Normal"]), Paragraph(v, styles["Right"])]
-    def money(x): return f"RM{float(x or 0):,.2f}"
-    subtotal = getattr(order,"subtotal", None)
-    tax_total = getattr(order,"tax_total", None)
-    shipping = getattr(order,"delivery_fee", None)
-    other = getattr(order,"other_fee", None)
-    rounding = getattr(order,"rounding", None)
-    deposit = getattr(order,"deposit_paid", None)
-    total = getattr(order,"total", None)
+    def row(k, v):
+        return [Paragraph(k, styles["Normal"]), Paragraph(v, styles["Right"])]
+
+    def money(x):
+        return f"RM{float(x or 0):,.2f}"
+
+    subtotal = getattr(order, "subtotal", None)
+    tax_total = getattr(order, "tax_total", None)
+    shipping = getattr(order, "delivery_fee", None)
+    other = getattr(order, "other_fee", None)
+    rounding = getattr(order, "rounding", None)
+    deposit = getattr(order, "deposit_paid", None)
+    total = getattr(order, "total", None)
     summary = []
-    if subtotal is not None: summary.append(row("Subtotal", money(subtotal)))
-    if tax_total is not None: summary.append(row("Tax", money(tax_total)))
-    if shipping: summary.append(row("Shipping", money(shipping)))
-    if other: summary.append(row("Other", money(other)))
-    if rounding: summary.append(row("Rounding", money(rounding)))
-    if deposit: summary.append(row("Deposit Paid", "-" + money(deposit)))
-    if total is not None: summary.append(row("Total", money(total)))
+    if subtotal is not None:
+        summary.append(row("Subtotal", money(subtotal)))
+    if tax_total is not None:
+        summary.append(row("Tax", money(tax_total)))
+    if shipping:
+        summary.append(row("Shipping", money(shipping)))
+    if other:
+        summary.append(row("Other", money(other)))
+    if rounding:
+        summary.append(row("Rounding", money(rounding)))
+    if deposit:
+        summary.append(row("Deposit Paid", "-" + money(deposit)))
+    if total is not None:
+        summary.append(row("Total", money(total)))
     if summary:
-        stab = Table(summary, colWidths=[45*mm, 45*mm], hAlign="RIGHT")
-        stab.setStyle(TableStyle([("ALIGN",(1,0),(-1,-1),"RIGHT"), ("LINEABOVE",(0,-1),(-1,-1),0.5,colors.black)]))
-        elems.append(KeepTogether([stab, Spacer(1,8)]))
+        stab = Table(summary, colWidths=[45 * mm, 45 * mm], hAlign="RIGHT")
+        stab.setStyle(
+            TableStyle(
+                [
+                    ("ALIGN", (1, 0), (-1, -1), "RIGHT"),
+                    ("LINEABOVE", (0, -1), (-1, -1), 0.5, colors.black),
+                ]
+            )
+        )
+        elems.append(KeepTogether([stab, Spacer(1, 8)]))
 
-    pay = getattr(order,"company", None) or type("X",(),{})()
-    lines = [getattr(pay,"bank_name","") or "", getattr(pay,"bank_account_name","") or "", getattr(pay,"bank_account_no","") or ""]
-    p = [ Paragraph("<br/>".join([x for x in lines if x]), styles["Normal"]) ]
-    qr = getattr(getattr(order,"payment", None),"qrDataUrl", None)
+    pay = getattr(order, "company", None) or type("X", (), {})()
+    lines = [
+        getattr(pay, "bank_name", "") or "",
+        getattr(pay, "bank_account_name", "") or "",
+        getattr(pay, "bank_account_no", "") or "",
+    ]
+    p = [Paragraph("<br/>".join([x for x in lines if x]), styles["Normal"])]
+    qr = getattr(getattr(order, "payment", None), "qrDataUrl", None)
     if qr:
         try:
             import base64
-            img_data = qr.split(",",1)[-1]
-            qr_img = Image(BytesIO(base64.b64decode(img_data)), width=40*mm, height=40*mm)
-            ptab = Table([[p, qr_img]], colWidths=[90*mm, 40*mm])
+
+            img_data = qr.split(",", 1)[-1]
+            qr_img = Image(
+                BytesIO(base64.b64decode(img_data)), width=40 * mm, height=40 * mm
+            )
+            ptab = Table([[p, qr_img]], colWidths=[90 * mm, 40 * mm])
         except Exception:
-            ptab = Table([[p]], colWidths=[90*mm])
+            ptab = Table([[p]], colWidths=[90 * mm])
     else:
-        ptab = Table([[p]], colWidths=[90*mm])
-    ptab.setStyle(TableStyle([("BOX",(0,0),(-1,-1),0.5,colors.grey), ("LEFTPADDING",(0,0),(-1,-1),8), ("RIGHTPADDING",(0,0),(-1,-1),8), ("TOPPADDING",(0,0),(-1,-1),8), ("BOTTOMPADDING",(0,0),(-1,-1),8)]))
-    elems += [ptab, Spacer(1,12)]
+        ptab = Table([[p]], colWidths=[90 * mm])
+    ptab.setStyle(
+        TableStyle(
+            [
+                ("BOX", (0, 0), (-1, -1), 0.5, colors.grey),
+                ("LEFTPADDING", (0, 0), (-1, -1), 8),
+                ("RIGHTPADDING", (0, 0), (-1, -1), 8),
+                ("TOPPADDING", (0, 0), (-1, -1), 8),
+                ("BOTTOMPADDING", (0, 0), (-1, -1), 8),
+            ]
+        )
+    )
+    elems += [ptab, Spacer(1, 12)]
 
     terms = getattr(getattr(order, "footer", None), "terms", None) or [
         "Payment due upon receipt.",
@@ -273,14 +525,21 @@ def invoice_pdf(order: Order) -> bytes:
     for para in malay_terms:
         elems.append(Paragraph(para, styles["Small"]))
         elems.append(Spacer(1, 4))
-    elems += [Paragraph("Terms & Conditions", styles["Heading2"]), Spacer(1,8), Paragraph("<br/>".join(f"• {t}" for t in terms), styles["Small"])]
+    elems += [
+        Paragraph("Terms & Conditions", styles["Heading2"]),
+        Spacer(1, 8),
+        Paragraph("<br/>".join(f"• {t}" for t in terms), styles["Small"]),
+    ]
 
     def _canvasmaker(*a, **k):
         from reportlab.pdfgen.canvas import Canvas
+
         k["pageCompression"] = 0
         return Canvas(*a, **k)
 
-    doc.build(elems, onFirstPage=_page_deco, onLaterPages=_page_deco, canvasmaker=_canvasmaker)
+    doc.build(
+        elems, onFirstPage=_page_deco, onLaterPages=_page_deco, canvasmaker=_canvasmaker
+    )
     pdf = buf.getvalue()
     buf.close()
     return pdf
@@ -341,7 +600,9 @@ def installment_agreement_pdf(order: Order, plan: Plan) -> bytes:
 
     try:
         pdfmetrics.registerFont(TTFont("Inter", "/app/static/fonts/Inter-Regular.ttf"))
-        pdfmetrics.registerFont(TTFont("Inter-Bold", "/app/static/fonts/Inter-Bold.ttf"))
+        pdfmetrics.registerFont(
+            TTFont("Inter-Bold", "/app/static/fonts/Inter-Bold.ttf")
+        )
         BASE_FONT = "Inter"
         BASE_BOLD = "Inter-Bold"
     except Exception:
@@ -351,7 +612,9 @@ def installment_agreement_pdf(order: Order, plan: Plan) -> bytes:
     styles = getSampleStyleSheet()
     styles["Normal"].fontName = BASE_FONT
     styles["Title"].fontName = BASE_BOLD
-    styles.add(ParagraphStyle(name="Small", parent=styles["Normal"], fontSize=9, leading=11))
+    styles.add(
+        ParagraphStyle(name="Small", parent=styles["Normal"], fontSize=9, leading=11)
+    )
 
     buf = BytesIO()
     doc = SimpleDocTemplate(
@@ -364,7 +627,11 @@ def installment_agreement_pdf(order: Order, plan: Plan) -> bytes:
     )
     elems = []
 
-    elems.append(Paragraph(f"INSTALLMENT AGREEMENT ({getattr(order, 'code', '')})", styles["Title"]))
+    elems.append(
+        Paragraph(
+            f"INSTALLMENT AGREEMENT ({getattr(order, 'code', '')})", styles["Title"]
+        )
+    )
     elems.append(Spacer(1, 8))
     elems.append(Paragraph(getattr(settings, "COMPANY_NAME", ""), styles["Normal"]))
     elems.append(Paragraph(getattr(settings, "COMPANY_ADDRESS", ""), styles["Small"]))
@@ -393,7 +660,9 @@ def installment_agreement_pdf(order: Order, plan: Plan) -> bytes:
         "Title remains with company until fully paid.",
     ]
     elems.append(Paragraph("Terms:", styles["Heading2"]))
-    elems.append(Paragraph("<br/>".join(f"• {t}" for t in bullet_terms), styles["Normal"]))
+    elems.append(
+        Paragraph("<br/>".join(f"• {t}" for t in bullet_terms), styles["Normal"])
+    )
     elems.append(PageBreak())
 
     elems.append(Paragraph("Terms & Conditions", styles["Heading2"]))
@@ -473,4 +742,3 @@ def installment_agreement_pdf(order: Order, plan: Plan) -> bytes:
     pdf = buf.getvalue()
     buf.close()
     return pdf
-

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -27,3 +27,4 @@ PyJWT>=2.8
 Pillow>=10.0
 python-multipart>=0.0.6
 httpx>=0.27
+weasyprint>=61

--- a/backend/static/invoice/invoice.css
+++ b/backend/static/invoice/invoice.css
@@ -1,0 +1,124 @@
+.invoice-box {
+    max-width: 800px;
+    margin: auto;
+    padding: 30px;
+    border: 1px solid #eee;
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.15);
+    font-size: 16px;
+    line-height: 24px;
+    font-family: 'Helvetica Neue', 'Helvetica', Helvetica, Arial, sans-serif;
+    color: #555;
+}
+
+.invoice-box table {
+    width: 100%;
+    line-height: inherit;
+    text-align: left;
+}
+
+.invoice-box table td {
+    padding: 5px;
+    vertical-align: top;
+}
+
+.invoice-box table tr td:nth-child(2) {
+    text-align: right;
+}
+
+.invoice-box table tr.top table td {
+    padding-bottom: 20px;
+}
+
+.invoice-box table tr.top table td.title {
+    font-size: 45px;
+    line-height: 45px;
+    color: #333;
+}
+
+.invoice-box table tr.information table td {
+    padding-bottom: 40px;
+}
+
+.invoice-box table tr.heading td {
+    background: #eee;
+    border-bottom: 1px solid #ddd;
+    font-weight: bold;
+}
+
+.invoice-box table tr.item td {
+    border-bottom: 1px solid #eee;
+}
+
+.invoice-box table tr.item.last td {
+    border-bottom: none;
+}
+
+.invoice-box table tr.total td {
+    border-top: 2px solid #eee;
+    font-weight: bold;
+}
+
+/* item table numeric alignment */
+.qty,
+.price,
+.line {
+    text-align: right;
+}
+
+.totals td:last-child {
+    text-align: right;
+}
+
+.bank {
+    margin-top: 30px;
+}
+
+.bank table {
+    width: 100%;
+}
+
+.bank .qr img {
+    width: 100%;
+    max-width: 120px;
+}
+
+.notes {
+    margin-top: 20px;
+    font-size: 12px;
+    color: #777;
+}
+
+@media only screen and (max-width: 600px) {
+    .invoice-box table tr.top table td {
+        width: 100%;
+        display: block;
+        text-align: center;
+    }
+
+    .invoice-box table tr.information table td {
+        width: 100%;
+        display: block;
+        text-align: center;
+    }
+}
+
+/** RTL **/
+.invoice-box.rtl {
+    direction: rtl;
+    font-family: Tahoma, 'Helvetica Neue', 'Helvetica', Helvetica, Arial, sans-serif;
+}
+
+.invoice-box.rtl table {
+    text-align: right;
+}
+
+.invoice-box.rtl table tr td:nth-child(2) {
+    text-align: left;
+}
+
+@media print {
+    .invoice-box {
+        box-shadow: none;
+        border: none;
+    }
+}

--- a/backend/templates/invoice/README.md
+++ b/backend/templates/invoice/README.md
@@ -1,0 +1,3 @@
+This invoice template is based on the [Sparksuite Simple HTML Invoice Template](https://github.com/sparksuite/simple-html-invoice-template).
+
+The original work is licensed under the MIT License. See `THIRD_PARTY/sparksuite_simple_html_invoice_template_LICENSE.txt` for details.

--- a/backend/templates/invoice/invoice.html
+++ b/backend/templates/invoice/invoice.html
@@ -1,0 +1,144 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <title>{{ doc_title }}</title>
+</head>
+<body>
+<div class="invoice-box{% if rtl %} rtl{% endif %}">
+    <table cellpadding="0" cellspacing="0">
+        <tr class="top">
+            <td colspan="4">
+                <table>
+                    <tr>
+                        <td class="title">
+                            {% if company.logo_url %}
+                            <img src="{{ company.logo_url }}" style="width:100%; max-width:300px" />
+                            {% else %}
+                            {{ company.name }}
+                            {% endif %}
+                        </td>
+                        <td>
+                            {{ doc_title }} #: {{ invoice.number }}<br />
+                            {{ invoice.date }}<br />
+                            {% if invoice.due_date %}Due: {{ invoice.due_date }}{% endif %}
+                        </td>
+                    </tr>
+                </table>
+            </td>
+        </tr>
+
+        <tr class="information">
+            <td colspan="4">
+                <table>
+                    <tr>
+                        <td>
+                            {{ company.name }}{% if company.reg_no %} ({{ company.reg_no }}){% endif %}<br />
+                            {% for line in company.address_lines %}{{ line }}<br />{% endfor %}
+                            {% if company.phone %}{{ company.phone }}<br />{% endif %}
+                            {% if company.email %}{{ company.email }}{% endif %}
+                        </td>
+                        <td>
+                            {{ bill_to.name }}<br />
+                            {% for line in bill_to.address_lines %}{{ line }}<br />{% endfor %}
+                            {% if bill_to.phone %}{{ bill_to.phone }}<br />{% endif %}
+                            {% if bill_to.email %}{{ bill_to.email }}{% endif %}
+                        </td>
+                    </tr>
+                </table>
+            </td>
+        </tr>
+
+        {% if ship_to %}
+        <tr class="information">
+            <td colspan="4">
+                <table>
+                    <tr>
+                        <td>Ship To:</td>
+                        <td>
+                            {{ ship_to.name }}<br />
+                            {% for line in ship_to.address_lines %}{{ line }}<br />{% endfor %}
+                        </td>
+                    </tr>
+                </table>
+            </td>
+        </tr>
+        {% endif %}
+
+        <tr class="heading">
+            <td>Description</td>
+            <td class="qty">Qty</td>
+            <td class="price">Unit Price</td>
+            <td class="line">Amount</td>
+        </tr>
+
+        {% for it in items %}
+        <tr class="item{% if loop.last %} last{% endif %}">
+            <td>{{ it.description }}</td>
+            <td class="qty">{{ "%.2f"|format(it.qty) }}</td>
+            <td class="price">{{ "%.2f"|format(it.unit_price) }}</td>
+            <td class="line">{{ "%.2f"|format(it.line_total) }}</td>
+        </tr>
+        {% endfor %}
+
+        <tr class="total">
+            <td colspan="3">Subtotal</td>
+            <td>{{ "%.2f"|format(summary.subtotal) }}</td>
+        </tr>
+        {% if summary.discount %}
+        <tr class="total">
+            <td colspan="3">Discount</td>
+            <td>-{{ "%.2f"|format(summary.discount) }}</td>
+        </tr>
+        {% endif %}
+        {% if summary.delivery_fee %}
+        <tr class="total">
+            <td colspan="3">Delivery Fee</td>
+            <td>{{ "%.2f"|format(summary.delivery_fee) }}</td>
+        </tr>
+        {% endif %}
+        {% if summary.penalty_amount %}
+        <tr class="total">
+            <td colspan="3">Penalty</td>
+            <td>{{ "%.2f"|format(summary.penalty_amount) }}</td>
+        </tr>
+        {% endif %}
+        {% if summary.buyback_amount %}
+        <tr class="total">
+            <td colspan="3">Buyback</td>
+            <td>-{{ "%.2f"|format(summary.buyback_amount) }}</td>
+        </tr>
+        {% endif %}
+        <tr class="total">
+            <td colspan="3">{{ company.tax_label }}{% if company.tax_percent %} ({{ company.tax_percent }}%) {% endif %}</td>
+            <td>{{ "%.2f"|format(summary.tax_amount) }}</td>
+        </tr>
+        <tr class="total">
+            <td colspan="3">Total</td>
+            <td>{{ "%.2f"|format(summary.total) }}</td>
+        </tr>
+    </table>
+
+    <div class="bank">
+        <table>
+            <tr>
+                <td>
+                    {% if company.bank.name %}{{ company.bank.name }}<br />{% endif %}
+                    {% if company.bank.beneficiary %}{{ company.bank.beneficiary }}<br />{% endif %}
+                    {% if company.bank.acct_no %}Account: {{ company.bank.acct_no }}<br />{% endif %}
+                    {% if company.bank.iban %}IBAN: {{ company.bank.iban }}<br />{% endif %}
+                    {% if company.bank.swift %}SWIFT: {{ company.bank.swift }}<br />{% endif %}
+                </td>
+                {% if qr_url %}
+                <td class="qr"><img src="{{ qr_url }}" alt="QR" /></td>
+                {% endif %}
+            </tr>
+        </table>
+    </div>
+
+    {% if notes %}
+    <p class="notes">{{ notes }}</p>
+    {% endif %}
+</div>
+</body>
+</html>

--- a/docs/DEV_SETUP.md
+++ b/docs/DEV_SETUP.md
@@ -1,0 +1,11 @@
+# Development Setup
+
+## WeasyPrint on Windows
+
+WeasyPrint depends on the Cairo, Pango, and GDK-PixBuf libraries. On Windows:
+
+1. Install the [GTK3 runtime for Windows](https://github.com/tschoonj/GTK-for-Windows-Runtime-Environment-Installer/releases).
+2. Add the GTK\bin directory to your `PATH`.
+3. Install Python dependencies: `pip install -r backend/requirements.txt`.
+
+Without these libraries, PDF rendering with WeasyPrint will fail. The application will fall back to the legacy ReportLab renderer when the `USE_HTML_TEMPLATE_INVOICE` environment variable is not set to `1`.


### PR DESCRIPTION
## Summary
- vendor Sparksuite HTML invoice template and stylesheet
- render invoices with WeasyPrint when `USE_HTML_TEMPLATE_INVOICE=1`
- document Windows setup for WeasyPrint and add third-party license notice

## Testing
- `python -m black backend/app/services/documents.py backend/tests/test_documents.py`
- `pytest backend/tests/test_documents.py::test_invoice_template_smoke backend/tests/test_documents.py::test_invoice_pdf_bytes backend/tests/test_documents.py::test_credit_note_title backend/tests/test_documents.py::test_receipt_pdf_generates_bytes backend/tests/test_documents.py::test_installment_agreement_pdf_generates_bytes -q`


------
https://chatgpt.com/codex/tasks/task_b_68af42dfca6c832eb80b77b325317d85