### PR TITLE
Fix Alembic version string exceeding column limit

### DIFF
--- a/backend/alembic/versions/0011_add_upfront_billed_to_plans.py
+++ b/backend/alembic/versions/0011_add_upfront_billed_to_plans.py
@@ -1,7 +1,7 @@
 from alembic import op
 import sqlalchemy as sa
 
-revision = '0011_add_upfront_billed_amount_to_plans'
+revision = '0011_add_upfront_billed_to_plans'
 down_revision = '0010_update_driver_device_fields'
 branch_labels = None
 depends_on = None


### PR DESCRIPTION
## Summary
- shorten migration revision identifier so it fits within the 32-character `alembic_version.version_num` column

## Testing
- `pytest backend/tests` *(fails: test_credit_note_title - AssertionError: assert 'CREDIT NOTE' in 'INVOICE #: ORD001...')*

------
https://chatgpt.com/codex/tasks/task_b_68af537a9ee4832eacc6abc3117c506f