### PR TITLE
feat: add manual order link and plan months

### DIFF
--- a/frontend/components/Layout.tsx
+++ b/frontend/components/Layout.tsx
@@ -8,6 +8,7 @@ import {
   FileDown,
   BarChart2,
   CircleDollarSign,
+  FilePlus,
   Wrench,
   Menu,
   Shield,
@@ -26,6 +27,7 @@ export type NavItem = {
 export const navItems: NavItem[] = [
   { href: '/', label: 'nav.intake', Icon: Inbox },
   { href: '/orders', label: 'nav.orders', Icon: ClipboardList },
+  { href: '/orders/new', label: 'orders.create', Icon: FilePlus },
   { href: '/export', label: 'nav.export', Icon: FileDown },
   { href: '/reports/outstanding', label: 'nav.reports', Icon: BarChart2 },
   { href: '/cashier', label: 'nav.cashier', Icon: CircleDollarSign },

--- a/frontend/pages/orders/new.tsx
+++ b/frontend/pages/orders/new.tsx
@@ -223,6 +223,7 @@ export default function NewOrderPage(){
               <option>RENTAL</option>
             </select>
           </div>
+          <div className="col"><label>Months</label><input className="input" value={planMonths} onChange={e=>setPlanMonths(e.target.value)} /></div>
           <div className="col"><label>Monthly Amount</label><input className="input" value={planMonthly} onChange={e=>setPlanMonthly(e.target.value)} /></div>
         </div>
 


### PR DESCRIPTION
## Summary
- add Manual Order link to navbar
- allow specifying plan months when creating orders

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68af4c2bfd30832ebb4185a9617d69db