### PR TITLE
Use orders push channel

### DIFF
--- a/README_PUSH.md
+++ b/README_PUSH.md
@@ -1,0 +1,12 @@
+# Push Notification Debugging
+
+Send a test push notification using the backend debug endpoint. The backend will use the
+Android channel `orders` by default (overridable via `PUSH_ANDROID_CHANNEL_ID`).
+
+```bash
+curl -X POST http://localhost:8000/debug/push \
+  -H 'Content-Type: application/json' \
+  -d '{"token":"<FCM_TOKEN>","title":"Test","body":"Hello","data":{}}'
+```
+```
+

--- a/backend/app/core/push.py
+++ b/backend/app/core/push.py
@@ -1,0 +1,4 @@
+import os
+
+PUSH_ANDROID_CHANNEL_ID = os.getenv("PUSH_ANDROID_CHANNEL_ID", "orders")
+

--- a/backend/app/services/fcm.py
+++ b/backend/app/services/fcm.py
@@ -7,6 +7,7 @@ from google.auth.transport.requests import Request
 from google.oauth2 import service_account
 from sqlalchemy.orm import Session
 
+from ..core.push import PUSH_ANDROID_CHANNEL_ID
 from ..models import Driver, Order
 
 _SCOPES = ["https://www.googleapis.com/auth/firebase.messaging"]
@@ -44,7 +45,7 @@ def send_to_token(token: str, title: str, body: str, data: Dict[str, Any]) -> No
             "data": data,
             "android": {
                 "priority": "HIGH",
-                "notification": {"channel_id": "orders_high"},
+                "notification": {"channel_id": PUSH_ANDROID_CHANNEL_ID},
             },
         }
     }


### PR DESCRIPTION
## Summary
- centralize PUSH_ANDROID_CHANNEL_ID with default `orders`
- send FCM notifications using unified Android channel
- document debug push endpoint usage

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pdfminer')*


------
https://chatgpt.com/codex/tasks/task_b_68af8c56f134832e921795b3ffb4c6ec