### PR TITLE
feat: add audit kit and improve push notifications

### DIFF
--- a/README_PUSH.md
+++ b/README_PUSH.md
@@ -1,12 +1,39 @@
-# Push Notification Debugging
+# Push Notification Smoke Tests
 
-Send a test push notification using the backend debug endpoint. The backend will use the
-Android channel `orders` by default (overridable via `PUSH_ANDROID_CHANNEL_ID`).
+## Env
+
+Ensure on Render:
+
+FIREBASE_SERVICE_ACCOUNT_JSON = full JSON
+
+DATABASE_URL set
+
+PUSH_ANDROID_CHANNEL_ID=orders (or whatever matches app)
+
+Optional local .env example:
+
+PUSH_ANDROID_CHANNEL_ID=orders
+
+## Audit routes check
 
 ```bash
-curl -X POST http://localhost:8000/debug/push \
-  -H 'Content-Type: application/json' \
-  -d '{"token":"<FCM_TOKEN>","title":"Test","body":"Hello","data":{}}'
-```
+curl -s https://<API_BASE>/_audit/routes | jq
 ```
 
+## FCM health
+
+```bash
+curl -s https://<API_BASE>/_audit/fcm | jq
+# expect: {"ok":true,"project_id":"...","access_token_len":...}
+```
+
+## Get device token from the app
+
+Open the driver app (RN), ensure it creates channel "orders" and logs/shows FCM token.
+
+## DB & token presence
+
+```bash
+curl -s "https://<API_BASE>/_audit/db?driver_id=<DRIVER_ID>" | jq
+# expect: tokens array with recent entries
+```

--- a/backend/app/audit.py
+++ b/backend/app/audit.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from fastapi import APIRouter, Depends, Request
+from sqlalchemy import select, text
+from sqlalchemy.orm import Session
+
+from .core.push import PUSH_ANDROID_CHANNEL_ID
+from .db import get_session
+from .models.driver import DriverDevice
+from .services.fcm import _get_access_token, send_to_token
+
+router = APIRouter(prefix="/_audit", tags=["audit"])
+
+
+@router.get("/routes")
+def audit_routes(request: Request) -> list[Dict[str, Any]]:
+    routes: list[Dict[str, Any]] = []
+    for r in request.app.routes:
+        path = getattr(r, "path", None)
+        methods = getattr(r, "methods", None)
+        if path and methods:
+            routes.append({"path": path, "methods": sorted(list(methods))})
+    return routes
+
+
+@router.get("/db")
+def audit_db(driver_id: int | None = None, db: Session = Depends(get_session)) -> Dict[str, Any]:
+    try:
+        db.execute(text("SELECT 1"))
+        result: Dict[str, Any] = {"ok": True}
+        if driver_id is not None:
+            q = (
+                select(DriverDevice.token)
+                .where(DriverDevice.driver_id == driver_id)
+                .order_by(DriverDevice.id.desc())
+                .limit(10)
+            )
+            result["tokens"] = db.execute(q).scalars().all()
+        return result
+    except Exception as e:  # pragma: no cover - audit helper
+        return {"ok": False, "reason": str(e)}
+
+
+@router.get("/fcm")
+def audit_fcm() -> Dict[str, Any]:
+    try:
+        access_token, project_id = _get_access_token()
+        return {
+            "ok": True,
+            "project_id": project_id,
+            "access_token_len": len(access_token),
+        }
+    except Exception as e:  # pragma: no cover - audit helper
+        return {"ok": False, "reason": str(e)}
+
+
+@router.post("/push")
+def audit_push(payload: Dict[str, Any]) -> Dict[str, Any]:
+    token = payload.get("token")
+    title = payload.get("title") or ""
+    body = payload.get("body") or ""
+    data = payload.get("data") or {}
+    channel = payload.get("channel_id") or PUSH_ANDROID_CHANNEL_ID
+    try:
+        status, resp_body = send_to_token(token, title, body, data, channel)
+        return {"ok": True, "status": status, "body": resp_body}
+    except Exception as e:  # pragma: no cover - audit helper
+        return {"ok": False, "reason": str(e)}

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -17,6 +17,7 @@ from .routers import (
     drivers,
     routes as routes_router,
 )
+from .audit import router as audit_router
 
 app = FastAPI(title="OrderOps Fullstack v1", default_response_class=ORJSONResponse)
 
@@ -42,3 +43,4 @@ app.include_router(queue.router)
 app.include_router(reports.router)
 app.include_router(drivers.router)
 app.include_router(routes_router.router)
+app.include_router(audit_router)

--- a/driver-app/android/app/src/main/java/com/yourco/driverAA/push/MyFcmService.kt
+++ b/driver-app/android/app/src/main/java/com/yourco/driverAA/push/MyFcmService.kt
@@ -3,18 +3,12 @@ package com.yourco.driverAA.push
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.PendingIntent
-import android.content.Context
 import android.content.Intent
 import android.os.Build
-import android.util.Log
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
-import com.google.firebase.messaging.FirebaseMessaging
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
-import java.net.HttpURLConnection
-import java.net.URL
-import org.json.JSONObject
 import android.Manifest
 import android.content.pm.PackageManager
 import androidx.core.content.ContextCompat
@@ -23,7 +17,7 @@ import androidx.appcompat.app.AppCompatActivity
 class MyFcmService : FirebaseMessagingService() {
     override fun onNewToken(token: String) {
         super.onNewToken(token)
-        registerToken(applicationContext, token)
+        // Token registration handled in React Native layer.
     }
 
     override fun onMessageReceived(message: RemoteMessage) {
@@ -71,33 +65,7 @@ class MyFcmService : FirebaseMessagingService() {
     }
 
     companion object {
-        private const val CHANNEL_ID = "orders_high"
-
-        fun registerToken(context: Context, token: String) {
-            try {
-                val url = URL("https://your-backend.example.com/api/driver/devices")
-                val conn = url.openConnection() as HttpURLConnection
-                conn.requestMethod = "POST"
-                conn.doOutput = true
-                conn.setRequestProperty("Content-Type", "application/json")
-                val payload = JSONObject().apply {
-                    put("token", token)
-                    put("platform", "android")
-                    put("app_version", BuildConfig.VERSION_NAME)
-                    put("model", android.os.Build.MODEL)
-                }
-                conn.outputStream.use { it.write(payload.toString().toByteArray()) }
-                conn.responseCode
-            } catch (e: Exception) {
-                Log.w("MyFcmService", "registerToken failed", e)
-            }
-        }
-
-        fun refreshToken(context: Context) {
-            FirebaseMessaging.getInstance().token.addOnSuccessListener {
-                registerToken(context, it)
-            }
-        }
+        private const val CHANNEL_ID = "orders"
 
         fun requestPermission(activity: AppCompatActivity, requestCode: Int = 1001) {
             if (Build.VERSION.SDK_INT >= 33 &&


### PR DESCRIPTION
## Summary
- expose PUSH_ANDROID_CHANNEL_ID env and log FCM HTTP errors
- add /_audit endpoints for routes, db, fcm auth, and push tests
- drop native Android token registration in favor of RN flow

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pdfminer')*


------
https://chatgpt.com/codex/tasks/task_b_68af912a3474832eaee05103e481aec3