### PR TITLE
feat(driver-app): add offline outbox and api client

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,3 +90,12 @@ runs via `GET /export/runs`, inspect their payments with
 
 The frontend now includes a **Cashier** page for quick payment entry and an
 **Adjustments** wizard for returns, buybacks and installment cancellations.
+
+## Offline Outbox & API Client
+
+The Expo-based driver app routes all HTTP calls through a centralized client
+that injects the Firebase ID token and normalizes JSON or text responses. Any
+mutating request made while offline is stored in an AsyncStorage-backed outbox
+and retried with exponential backoff when connectivity is restored or the app
+foregrounds. A lightweight toast system surfaces errors and queued actions to
+the driver.

--- a/driver-app/App.tsx
+++ b/driver-app/App.tsx
@@ -1,11 +1,30 @@
 import React from 'react';
+import auth from '@react-native-firebase/auth';
+import { setTokenGetter } from './src/lib/api';
+import { OutboxProvider } from './src/offline/useOutbox';
+import Toast from './src/components/Toast';
 import { useAuth } from './src/hooks/useAuth';
 import { useNotifications } from './src/hooks/useNotifications';
 import Login from './src/screens/Login';
 import Home from './src/screens/Home';
 
+setTokenGetter(async () => {
+  const current = auth().currentUser;
+  return current ? await current.getIdToken() : undefined;
+});
+
+function AuthedApp() {
+  useNotifications();
+  return <Home />;
+}
+
 export default function App() {
   const { user } = useAuth();
-  useNotifications();
-  return user ? <Home /> : <Login />;
+  return (
+    <OutboxProvider>
+      <Toast />
+      {user ? <AuthedApp /> : <Login />}
+    </OutboxProvider>
+  );
 }
+

--- a/driver-app/index.js
+++ b/driver-app/index.js
@@ -17,12 +17,9 @@ messaging().setBackgroundMessageHandler(async (msg) => {
     });
     // 2) OPTIONAL: headless fetch to stash new orders for instant UI
     try {
-      const idt = await AsyncStorage.getItem('idToken');
-      if (idt) {
-        const r = await api.get('/drivers/orders', idt);
-        if (r.ok) {
-          await AsyncStorage.setItem('pendingOrders', JSON.stringify(r.data?.data ?? r.data));
-        }
+      const r = await api.get('/drivers/orders');
+      if (r.ok) {
+        await AsyncStorage.setItem('pendingOrders', JSON.stringify(r.data?.data ?? r.data));
       }
     } catch {}
   }

--- a/driver-app/package-lock.json
+++ b/driver-app/package-lock.json
@@ -22,6 +22,10 @@
         "react": "18.2.0",
         "react-native": "0.74.0",
         "zustand": "^4.5.2"
+      },
+      "devDependencies": {
+        "ts-node": "^10.9.2",
+        "typescript": "^5.4.5"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -2272,6 +2276,30 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
     "node_modules/@expo/bunyan": {
@@ -5870,6 +5898,34 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
@@ -6002,6 +6058,19 @@
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
       },
       "engines": {
         "node": ">=0.4.0"
@@ -7171,6 +7240,13 @@
         "node": ">=4"
       }
     },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cross-fetch": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.2.0.tgz",
@@ -7462,6 +7538,16 @@
       },
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/dir-glob": {
@@ -10773,6 +10859,13 @@
       "bin": {
         "semver": "bin/semver"
       }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/makeerror": {
       "version": "1.0.12",
@@ -14423,6 +14516,57 @@
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "license": "Apache-2.0"
     },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-node/node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -14541,6 +14685,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/ua-parser-js": {
@@ -14755,6 +14913,13 @@
       "bin": {
         "uuid": "dist/bin/uuid"
       }
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/valid-url": {
       "version": "1.0.9",
@@ -15224,6 +15389,16 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {

--- a/driver-app/package.json
+++ b/driver-app/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "start": "expo start",
     "android": "expo run:android",
-    "ios": "expo run:ios"
+    "ios": "expo run:ios",
+    "test": "tsc src/lib/api.ts src/offline/outbox.ts src/offline/types.ts src/config/env.ts --outDir build --module commonjs --target ES2019 --esModuleInterop --skipLibCheck && node --test tests/api.test.js tests/outbox.test.js"
   },
   "dependencies": {
     "@react-native-firebase/app": "^21.4.0",
@@ -23,5 +24,9 @@
     "react": "18.2.0",
     "react-native": "0.74.0",
     "zustand": "^4.5.2"
+  },
+  "devDependencies": {
+    "ts-node": "^10.9.2",
+    "typescript": "^5.4.5"
   }
 }

--- a/driver-app/src/components/Toast.tsx
+++ b/driver-app/src/components/Toast.tsx
@@ -1,0 +1,54 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+type Variant = 'error' | 'info' | 'success';
+
+interface ToastState {
+  message: string;
+  variant: Variant;
+}
+
+let showHandler: ((msg: string, variant: Variant) => void) | null = null;
+
+export const toast = {
+  show(message: string, variant: Variant = 'info') {
+    showHandler?.(message, variant);
+  },
+};
+
+export default function Toast() {
+  const [state, setState] = useState<ToastState | null>(null);
+
+  useEffect(() => {
+    showHandler = (message, variant) => {
+      setState({ message, variant });
+      setTimeout(() => setState(null), 3500);
+    };
+    return () => {
+      showHandler = null;
+    };
+  }, []);
+
+  if (!state) return null;
+  const bg =
+    state.variant === 'error' ? '#dc2626' : state.variant === 'success' ? '#16a34a' : '#2563eb';
+  return (
+    <View style={[styles.container, { backgroundColor: bg }]} pointerEvents="none">
+      <Text style={styles.text}>{state.message}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    position: 'absolute',
+    top: 40,
+    alignSelf: 'center',
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    borderRadius: 4,
+    zIndex: 1000,
+  },
+  text: { color: '#fff' },
+});
+

--- a/driver-app/src/config/env.ts
+++ b/driver-app/src/config/env.ts
@@ -1,8 +1,19 @@
-import Constants from 'expo-constants';
-
-const API_BASE = (Constants.expoConfig?.extra as any)?.API_BASE;
-if (!API_BASE) {
-  throw new Error('Missing API_BASE environment value');
+let Constants: any;
+try {
+  Constants = require('expo-constants').default;
+} catch {
+  Constants = { expoConfig: { extra: { API_BASE: process.env.API_BASE, FIREBASE_PROJECT_ID: process.env.FIREBASE_PROJECT_ID } } };
 }
 
-export { API_BASE };
+export const API_BASE = (() => {
+  const v = Constants.expoConfig?.extra?.API_BASE as string | undefined;
+  if (!v) throw new Error('Missing API_BASE in app config');
+  return v.replace(/\/+$/, '');
+})();
+
+export const FIREBASE_PROJECT_ID = (() => {
+  const v = Constants.expoConfig?.extra?.FIREBASE_PROJECT_ID as string | undefined;
+  if (!v) throw new Error('Missing FIREBASE_PROJECT_ID in app config');
+  return v;
+})();
+

--- a/driver-app/src/hooks/useNetwork.ts
+++ b/driver-app/src/hooks/useNetwork.ts
@@ -1,0 +1,27 @@
+import { useEffect, useState } from 'react';
+import * as Network from 'expo-network';
+import { AppState } from 'react-native';
+
+export function useNetwork() {
+  const [online, setOnline] = useState(true);
+
+  const check = async () => {
+    try {
+      const st = await Network.getNetworkStateAsync();
+      setOnline(!!st.isConnected && st.isInternetReachable !== false);
+    } catch {
+      setOnline(false);
+    }
+  };
+
+  useEffect(() => {
+    check();
+    const sub = AppState.addEventListener('change', (s) => {
+      if (s === 'active') check();
+    });
+    return () => sub.remove();
+  }, []);
+
+  return { online };
+}
+

--- a/driver-app/src/hooks/useOrders.ts
+++ b/driver-app/src/hooks/useOrders.ts
@@ -1,48 +1,82 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import * as ImagePicker from 'expo-image-picker';
 import * as ImageManipulator from 'expo-image-manipulator';
-import { useOrderStore, Order } from '../stores/orderStore';
+import { AppState } from 'react-native';
+import { useOrderStore } from '../stores/orderStore';
 import { api } from '../lib/api';
-import { useAuth } from './useAuth';
+import { toast } from '../components/Toast';
+import { useNetwork } from './useNetwork';
+import { useOutbox } from '../offline/useOutbox';
+import { OutboxJob } from '../offline/types';
+
+const uuid = () => (globalThis.crypto?.randomUUID ? globalThis.crypto.randomUUID() : Math.random().toString(36).slice(2));
 
 interface Options {
   skipPolling?: boolean;
 }
 
+function formFromEntries(entries: [string, any][]) {
+  const f = new FormData();
+  entries.forEach(([k, v]) => f.append(k, v as any));
+  return f;
+}
+
 export function useOrders(options?: Options) {
-  const { idToken } = useAuth();
   const orders = useOrderStore((s) => s.orders);
   const setOrders = useOrderStore((s) => s.setOrders);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const timerRef = useRef<NodeJS.Timeout | null>(null);
+  const { online } = useNetwork();
+  const { enqueue, syncing } = useOutbox();
 
   const refresh = useCallback(async () => {
-    if (!idToken) return;
     setLoading(true);
     setError(null);
-    const res = await api.get('/drivers/orders', idToken);
+    const res = await api.get('/drivers/orders');
     if (res.ok) {
       setOrders(res.data?.data ?? res.data ?? []);
     } else {
       setError(res.error || String(res.status));
     }
     setLoading(false);
-  }, [idToken, setOrders]);
+  }, [setOrders]);
+
+  const enqueuePatch = useCallback(
+    async (id: number, status: string) => {
+      const job: OutboxJob = {
+        id: uuid(),
+        createdAt: Date.now(),
+        attempts: 0,
+        kind: 'PATCH',
+        url: `/drivers/orders/${id}`,
+        bodyType: 'json',
+        body: { status },
+      };
+      await enqueue(job);
+    },
+    [enqueue],
+  );
 
   const update = useCallback(
     async (id: number, status: string) => {
-      if (!idToken) return;
       setOrders((prev) => prev.map((o) => (o.id === id ? { ...o, status } : o)));
-      const res = await api.patch(`/drivers/orders/${id}`, idToken, { status });
-      if (!res.ok) refresh();
+      if (!online) {
+        await enqueuePatch(id, status);
+        toast.show('Queued. Will send when back online.');
+        return;
+      }
+      const res = await api.patch(`/drivers/orders/${id}`, { status });
+      if (!res.ok) {
+        await enqueuePatch(id, status);
+        toast.show(res.error || 'Failed to update. Will retry.', 'error');
+      }
     },
-    [idToken, setOrders, refresh],
+    [online, setOrders, enqueuePatch],
   );
 
   const completeWithPhoto = useCallback(
     async (id: number) => {
-      if (!idToken) return;
       const res = await ImagePicker.launchCameraAsync({ allowsEditing: false, quality: 0.7 });
       if (res.canceled) return;
       const asset = res.assets[0];
@@ -51,29 +85,88 @@ export function useOrders(options?: Options) {
         [{ resize: { width: 1280 } }],
         { compress: 0.7, format: ImageManipulator.SaveFormat.JPEG },
       );
-      const form = new FormData();
-      form.append('file', { uri: manip.uri, type: 'image/jpeg', name: 'pod.jpg' } as any);
-      await api.upload(`/drivers/orders/${id}/pod-photo`, idToken, form);
-      await update(id, 'DELIVERED');
+      const entries: [string, any][] = [
+        ['file', { uri: manip.uri, type: 'image/jpeg', name: 'pod.jpg' }],
+      ];
+      const uploadJob: OutboxJob = {
+        id: uuid(),
+        createdAt: Date.now(),
+        attempts: 0,
+        kind: 'UPLOAD',
+        url: `/drivers/orders/${id}/pod-photo`,
+        bodyType: 'formdata',
+        body: entries,
+      };
+      const patchJob: OutboxJob = {
+        id: uuid(),
+        createdAt: Date.now(),
+        attempts: 0,
+        kind: 'PATCH',
+        url: `/drivers/orders/${id}`,
+        bodyType: 'json',
+        body: { status: 'DELIVERED' },
+      };
+
+      if (!online) {
+        setOrders((prev) => prev.map((o) => (o.id === id ? { ...o, status: 'DELIVERED' } : o)));
+        await enqueue(uploadJob);
+        await enqueue(patchJob);
+        toast.show('Queued. Will send when back online.');
+        return;
+      }
+
+      const uploadRes = await api.upload(`/drivers/orders/${id}/pod-photo`, formFromEntries(entries));
+      if (!uploadRes.ok) {
+        if (uploadRes.status === 400 && uploadRes.error?.includes('PoD photo required')) {
+          toast.show('Proof of Delivery is required.', 'error');
+          return;
+        }
+        setOrders((prev) => prev.map((o) => (o.id === id ? { ...o, status: 'DELIVERED' } : o)));
+        await enqueue(uploadJob);
+        await enqueue(patchJob);
+        toast.show(uploadRes.error || 'Upload failed. Will retry.', 'error');
+        return;
+      }
+
+      const patchRes = await api.patch(`/drivers/orders/${id}`, { status: 'DELIVERED' });
+      if (!patchRes.ok) {
+        await enqueue(patchJob);
+        toast.show(patchRes.error || 'Failed to update. Will retry.', 'error');
+      } else {
+        setOrders((prev) => prev.map((o) => (o.id === id ? { ...o, status: 'DELIVERED' } : o)));
+      }
     },
-    [idToken, update],
+    [online, enqueue, setOrders],
   );
 
   const pendingCount = orders.filter((o) => o.status !== 'DELIVERED').length;
 
   useEffect(() => {
-    if (options?.skipPolling || !idToken) return;
-    refresh();
-    if (!timerRef.current) {
-      timerRef.current = setInterval(refresh, 20 * 60 * 1000);
-    }
-    return () => {
+    if (options?.skipPolling) return;
+
+    const start = () => {
+      if (!timerRef.current && AppState.currentState === 'active' && !syncing) {
+        refresh();
+        timerRef.current = setInterval(refresh, 15 * 60 * 1000);
+      }
+    };
+    const stop = () => {
       if (timerRef.current) {
         clearInterval(timerRef.current);
         timerRef.current = null;
       }
     };
-  }, [idToken, refresh, options?.skipPolling]);
+    start();
+    const sub = AppState.addEventListener('change', (s) => {
+      if (s === 'active') start();
+      else stop();
+    });
+    return () => {
+      stop();
+      sub.remove();
+    };
+  }, [refresh, options?.skipPolling, syncing]);
 
   return { orders, loading, error, refresh, update, completeWithPhoto, pendingCount };
 }
+

--- a/driver-app/src/lib/api.ts
+++ b/driver-app/src/lib/api.ts
@@ -7,11 +7,20 @@ export interface ApiResponse<T = any> {
   error?: string;
 }
 
-async function request(path: string, opts: RequestInit = {}, idToken?: string): Promise<ApiResponse> {
-  const headers: Record<string, string> = {
-    ...(opts.headers as Record<string, string>),
-  };
-  if (idToken) headers['Authorization'] = `Bearer ${idToken}`;
+type TokenGetter = () => Promise<string | undefined>;
+
+let getToken: TokenGetter = async () => undefined;
+
+export function setTokenGetter(fn: TokenGetter) {
+  getToken = fn;
+}
+
+async function request(path: string, opts: RequestInit = {}, extraHeaders?: Record<string, string>): Promise<ApiResponse> {
+  const headers: Record<string, string> = { ...(extraHeaders || {}), ...(opts.headers as Record<string, string>) };
+  try {
+    const token = await getToken();
+    if (token) headers['Authorization'] = `Bearer ${token}`;
+  } catch {}
   try {
     const res = await fetch(`${API_BASE}${path}`, { ...opts, headers });
     const ct = res.headers.get('content-type');
@@ -22,15 +31,16 @@ async function request(path: string, opts: RequestInit = {}, idToken?: string): 
       data = await res.text();
     }
     if (res.ok) return { ok: true, status: res.status, data };
-    return { ok: false, status: res.status, error: (data && data.error) || (typeof data === 'string' ? data : undefined) };
+    const err = typeof data === 'string' ? data : data?.error;
+    return { ok: false, status: res.status, error: err };
   } catch (e: any) {
     return { ok: false, status: 0, error: e?.message ?? String(e) };
   }
 }
 
 export const api = {
-  get: (path: string, idToken?: string) => request(path, { method: 'GET' }, idToken),
-  post: (path: string, idToken: string, body?: any) =>
+  get: (path: string, headers?: Record<string, string>) => request(path, { method: 'GET' }, headers),
+  post: (path: string, body?: any, headers?: Record<string, string>) =>
     request(
       path,
       {
@@ -38,9 +48,9 @@ export const api = {
         headers: { 'Content-Type': 'application/json' },
         body: body ? JSON.stringify(body) : undefined,
       },
-      idToken,
+      headers,
     ),
-  patch: (path: string, idToken: string, body?: any) =>
+  patch: (path: string, body?: any, headers?: Record<string, string>) =>
     request(
       path,
       {
@@ -48,15 +58,17 @@ export const api = {
         headers: { 'Content-Type': 'application/json' },
         body: body ? JSON.stringify(body) : undefined,
       },
-      idToken,
+      headers,
     ),
-  upload: (path: string, idToken: string, body: FormData) =>
+  delete: (path: string, headers?: Record<string, string>) => request(path, { method: 'DELETE' }, headers),
+  upload: (path: string, body: FormData, headers?: Record<string, string>) =>
     request(
       path,
       {
         method: 'POST',
         body,
       },
-      idToken,
+      headers,
     ),
 };
+

--- a/driver-app/src/offline/outbox.ts
+++ b/driver-app/src/offline/outbox.ts
@@ -1,0 +1,39 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { OutboxJob } from './types';
+
+const KEY = 'OUTBOX_V1';
+
+let storage: typeof AsyncStorage = AsyncStorage;
+
+export function __setStorage(s: typeof AsyncStorage) {
+  storage = s;
+}
+
+export async function list(): Promise<OutboxJob[]> {
+  const raw = await storage.getItem(KEY);
+  if (!raw) return [];
+  try {
+    return JSON.parse(raw) as OutboxJob[];
+  } catch {
+    return [];
+  }
+}
+
+export async function replaceAll(jobs: OutboxJob[]): Promise<void> {
+  await storage.setItem(KEY, JSON.stringify(jobs));
+}
+
+export async function enqueue(job: OutboxJob): Promise<void> {
+  const jobs = await list();
+  jobs.push(job);
+  await replaceAll(jobs);
+}
+
+export function backoff(attempts: number): number {
+  const base = 2000; // 2s
+  const max = 120000; // 2m
+  const exp = Math.min(base * Math.pow(2, attempts), max);
+  const jitter = Math.random() * base;
+  return exp + jitter;
+}
+

--- a/driver-app/src/offline/types.ts
+++ b/driver-app/src/offline/types.ts
@@ -1,0 +1,11 @@
+export type OutboxJob = {
+  id: string;
+  createdAt: number;
+  attempts: number;
+  kind: 'PATCH' | 'UPLOAD' | 'POST' | 'DELETE';
+  url: string;
+  headers?: Record<string, string>;
+  bodyType: 'json' | 'formdata' | 'none';
+  body?: any;
+};
+

--- a/driver-app/src/offline/useOutbox.tsx
+++ b/driver-app/src/offline/useOutbox.tsx
@@ -1,0 +1,97 @@
+import React, { createContext, useCallback, useContext, useEffect, useRef, useState } from 'react';
+import { AppState } from 'react-native';
+import { api } from '../lib/api';
+import { useNetwork } from '../hooks/useNetwork';
+import { OutboxJob } from './types';
+import { enqueue as persistEnqueue, list, replaceAll, backoff } from './outbox';
+
+interface Ctx {
+  enqueue: (job: OutboxJob) => Promise<void>;
+  syncing: boolean;
+  lastSyncAt: number | null;
+}
+
+const OutboxContext = createContext<Ctx | undefined>(undefined);
+
+function useProvider(): Ctx {
+  const { online } = useNetwork();
+  const [syncing, setSyncing] = useState(false);
+  const [lastSyncAt, setLastSyncAt] = useState<number | null>(null);
+  const timer = useRef<NodeJS.Timeout | null>(null);
+
+  const send = useCallback(async (job: OutboxJob) => {
+    switch (job.kind) {
+      case 'PATCH':
+        return api.patch(job.url, job.body, job.headers);
+      case 'POST':
+        return api.post(job.url, job.body, job.headers);
+      case 'UPLOAD': {
+        const form = new FormData();
+        (job.body as [string, any][]).forEach(([k, v]) => form.append(k, v as any));
+        return api.upload(job.url, form, job.headers);
+      }
+      case 'DELETE':
+        return api.delete(job.url, job.headers);
+      default:
+        return { ok: false, status: 0, error: 'unknown job' };
+    }
+  }, []);
+
+  const flush = useCallback(async () => {
+    if (syncing) return;
+    const jobs = await list();
+    if (!jobs.length) {
+      setLastSyncAt(Date.now());
+      return;
+    }
+    setSyncing(true);
+    let remaining = jobs;
+    for (const job of jobs) {
+      const res = await send(job);
+      if (res.ok) {
+        remaining = remaining.filter((j) => j.id !== job.id);
+        await replaceAll(remaining);
+      } else {
+        job.attempts += 1;
+        await replaceAll(remaining);
+        const delay = backoff(job.attempts);
+        if (timer.current) clearTimeout(timer.current);
+        timer.current = setTimeout(() => flush(), delay);
+        setSyncing(false);
+        return;
+      }
+    }
+    setSyncing(false);
+    setLastSyncAt(Date.now());
+  }, [send, syncing]);
+
+  useEffect(() => {
+    if (online) flush();
+  }, [online, flush]);
+
+  useEffect(() => {
+    const sub = AppState.addEventListener('change', (s) => {
+      if (s === 'active') flush();
+    });
+    return () => sub.remove();
+  }, [flush]);
+
+  const enqueue = useCallback(async (job: OutboxJob) => {
+    await persistEnqueue(job);
+    if (online) flush();
+  }, [flush, online]);
+
+  return { enqueue, syncing, lastSyncAt };
+}
+
+export const OutboxProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
+  const value = useProvider();
+  return <OutboxContext.Provider value={value}>{children}</OutboxContext.Provider>;
+};
+
+export function useOutbox() {
+  const ctx = useContext(OutboxContext);
+  if (!ctx) throw new Error('useOutbox must be used within OutboxProvider');
+  return ctx;
+}
+

--- a/driver-app/tests/api.test.js
+++ b/driver-app/tests/api.test.js
@@ -1,0 +1,32 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+process.env.API_BASE = 'https://example.com';
+process.env.FIREBASE_PROJECT_ID = 'demo';
+
+const { api, setTokenGetter } = require('../build/lib/api.js');
+
+test('api injects auth and parses json', async () => {
+  setTokenGetter(async () => 'token123');
+  global.fetch = async (url, opts) => {
+    assert.equal(url, 'https://example.com/test');
+    assert.equal(opts.headers['Authorization'], 'Bearer token123');
+    return new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  };
+  const res = await api.get('/test');
+  assert.equal(res.ok, true);
+  assert.deepEqual(res.data, { ok: true });
+});
+
+test('api handles non-json error', async () => {
+  setTokenGetter(async () => undefined);
+  global.fetch = async () => new Response('nope', { status: 500, headers: { 'content-type': 'text/plain' } });
+  const res = await api.get('/err');
+  assert.equal(res.ok, false);
+  assert.equal(res.error, 'nope');
+  assert.equal(res.status, 500);
+});
+

--- a/driver-app/tests/outbox.test.js
+++ b/driver-app/tests/outbox.test.js
@@ -1,0 +1,50 @@
+const { test, beforeEach } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { enqueue, list, replaceAll, backoff, __setStorage } = require('../build/offline/outbox.js');
+
+const memory = (() => {
+  let store = {};
+  return {
+    async getItem(k) {
+      return store[k] ?? null;
+    },
+    async setItem(k, v) {
+      store[k] = v;
+    },
+    async removeItem(k) {
+      delete store[k];
+    },
+  };
+})();
+
+__setStorage(memory);
+
+beforeEach(async () => {
+  await replaceAll([]);
+});
+
+test('enqueue and list', async () => {
+  const job = {
+    id: '1',
+    createdAt: Date.now(),
+    attempts: 0,
+    kind: 'POST',
+    url: '/x',
+    bodyType: 'json',
+    body: {},
+  };
+  await enqueue(job);
+  const jobs = await list();
+  assert.equal(jobs.length, 1);
+  assert.equal(jobs[0].id, '1');
+});
+
+test('backoff increases and caps', () => {
+  const d1 = backoff(0);
+  const d2 = backoff(1);
+  const d5 = backoff(5);
+  assert.ok(d2 > d1);
+  assert.ok(d5 <= 120000 + 2000);
+});
+

--- a/driver-app/tsconfig.json
+++ b/driver-app/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2019",
+    "module": "CommonJS",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "build",
+    "jsx": "react"
+  },
+  "include": ["src/**/*"]
+}
+


### PR DESCRIPTION
## Summary
- centralize API calls with auth token injection and normalized responses
- queue mutations in AsyncStorage-backed outbox with retry/backoff and toast feedback
- expose network hook and toast portal; wire outbox provider in App

## Testing
- `cd driver-app && npm test`


------
https://chatgpt.com/codex/tasks/task_b_68af94a6f0b4832eac7923eb84a9d234