### PR TITLE
driver-app: pass Firebase project ID via Expo extra

### DIFF
--- a/driver-app/app.config.ts
+++ b/driver-app/app.config.ts
@@ -29,6 +29,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
   // backend URL for the app
   extra: {
     API_BASE: process.env.API_BASE,
+    FIREBASE_PROJECT_ID: process.env.FIREBASE_PROJECT_ID,
   },
 
   runtimeVersion: { policy: "sdkVersion" },


### PR DESCRIPTION
## Summary
- expose FIREBASE_PROJECT_ID in driver-app Expo config

## Testing
- `npx -y -p typescript tsc src/lib/api.ts src/offline/outbox.ts src/offline/types.ts src/config/env.ts --outDir build --module commonjs --target ES2019 --esModuleInterop --skipLibCheck && node --test tests/api.test.js tests/outbox.test.js`

------
https://chatgpt.com/codex/tasks/task_b_68afa7b46484832eac91b3b8cc971199