### PR TITLE
feat(driver-app): show offline banner and pending outbox count

### DIFF
--- a/driver-app/App.tsx
+++ b/driver-app/App.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import auth from '@react-native-firebase/auth';
 import { setTokenGetter } from './src/lib/api';
-import { OutboxProvider } from './src/offline/useOutbox';
+import { OutboxProvider, useOutbox } from './src/offline/useOutbox';
 import Toast from './src/components/Toast';
 import { useAuth } from './src/hooks/useAuth';
 import { useNotifications } from './src/hooks/useNotifications';
+import { useNetwork } from './src/hooks/useNetwork';
+import { OfflineBanner } from './src/components/OfflineBanner';
 import Login from './src/screens/Login';
 import Home from './src/screens/Home';
 
@@ -18,12 +20,23 @@ function AuthedApp() {
   return <Home />;
 }
 
+function InnerApp({ user }: { user: any }) {
+  const { online } = useNetwork();
+  const { pending } = useOutbox();
+  return (
+    <>
+      <Toast />
+      <OfflineBanner online={online} pendingCount={pending} />
+      {user ? <AuthedApp /> : <Login />}
+    </>
+  );
+}
+
 export default function App() {
   const { user } = useAuth();
   return (
     <OutboxProvider>
-      <Toast />
-      {user ? <AuthedApp /> : <Login />}
+      <InnerApp user={user} />
     </OutboxProvider>
   );
 }

--- a/driver-app/src/components/OfflineBanner.tsx
+++ b/driver-app/src/components/OfflineBanner.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+
+export const OfflineBanner = ({ online, pendingCount }: { online: boolean; pendingCount: number }) => {
+  if (online && pendingCount === 0) return null;
+  return (
+    <View style={{ backgroundColor: '#FFF3CD', padding: 8 }}>
+      <Text style={{ color: '#664D03', fontWeight: '600' }}>
+        {online ? `Syncing pending actions: ${pendingCount}` : `Offline — ${pendingCount} action(s) queued`}
+      </Text>
+    </View>
+  );
+};
+


### PR DESCRIPTION
## Summary
- add reusable OfflineBanner component
- track pending outbox jobs and expose count
- display banner when offline or syncing queued actions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68afa7e4b260832e8b557d09d5ef2b5b