### PR TITLE
ci: write google services json safely

### DIFF
--- a/.github/workflows/driver-android-release.yml
+++ b/.github/workflows/driver-android-release.yml
@@ -37,11 +37,12 @@ jobs:
 
       - name: Write google-services.json
         working-directory: driver-app
-        run: |
-          mkdir -p android/app
-          echo "$GOOGLE_SERVICES_JSON" > android/app/google-services.json
         env:
           GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
+        run: |
+          test -n "$GOOGLE_SERVICES_JSON" || { echo "Missing GOOGLE_SERVICES_JSON secret"; exit 1; }
+          printf '%s' "$GOOGLE_SERVICES_JSON" > google-services.json
+          ls -l google-services.json
 
       - name: Sanity check (android.package vs google-services.json)
         run: |


### PR DESCRIPTION
## Summary
- ensure driver-app `google-services.json` writes safely at repo root

## Testing
- `npx --yes prettier@3.2.5 --check .github/workflows/driver-android-release.yml` *(fails: code style issues found)*

------
https://chatgpt.com/codex/tasks/task_b_68afadb83360832eb3f4bb86b5142fc6