### PR TITLE
fix(driver-android): use Expo bundler for release builds

### DIFF
--- a/.github/workflows/driver-android-release.yml
+++ b/.github/workflows/driver-android-release.yml
@@ -105,28 +105,12 @@ jobs:
       - name: Ensure Metro config exists
         working-directory: driver-app
         run: |
-          if [ ! -f metro.config.js ]; then
-            printf "const { getDefaultConfig } = require('expo/metro-config');\nmodule.exports = getDefaultConfig(__dirname);\n" > metro.config.js
-            echo "Created metro.config.js"
+          if [ ! -f metro.config.js ] || ! grep -q "expo/metro-config" metro.config.js; then
+            printf "const { getDefaultConfig } = require('expo/metro-config');\nconst config = getDefaultConfig(__dirname);\nmodule.exports = config;\n" > metro.config.js
+            echo "Wrote Expo metro.config.js"
           else
-            echo "metro.config.js already present"
+            echo "Expo metro.config.js already present"
           fi
-
-      - name: Create JS bundle for Release (offline)
-        working-directory: driver-app
-        run: |
-          mkdir -p android/app/src/main/assets
-          ENTRY="index.js"; [ -f "$ENTRY" ] || ENTRY="App.tsx"
-          npx react-native bundle \
-            --platform android \
-            --dev false \
-            --config metro.config.js \
-            --entry-file "$ENTRY" \
-            --bundle-output android/app/src/main/assets/index.android.bundle \
-            --assets-dest android/app/src/main/res
-          test -f android/app/src/main/assets/index.android.bundle || (echo "::error::Bundle not created"; exit 1)
-          echo "Bundled JS from $ENTRY"
-
       - name: Ensure gradlew exists
         id: gradle_check
         working-directory: driver-app/android
@@ -140,6 +124,9 @@ jobs:
             exit 1
           fi
 
+      - name: Clean old Android assets (optional)
+        working-directory: driver-app
+        run: rm -rf android/app/src/main/assets android/app/src/main/res/drawable-*/node_modules*
       - name: Build release APK
         if: steps.gradle_check.outputs.found == 'true'
         working-directory: driver-app/android

--- a/driver-app/android/app/build.gradle
+++ b/driver-app/android/app/build.gradle
@@ -4,6 +4,16 @@ plugins {
     id("com.google.gms.google-services")
 }
 
+react {
+    // Resolve @expo/cli path for Gradle
+    cliFile = new File(["node", "--print", "require.resolve('@expo/cli')"].execute(null, rootDir).text.trim())
+    // Use the Expo export bundler so assets/embedded bundle are created correctly
+    bundleCommand = "export:embed"
+    // Resolve the entry file via Expo helper (works with index.js or App.tsx)
+    def projectRoot = rootDir.getAbsoluteFile().getParentFile().getAbsolutePath()
+    entryFile = file(["node", "-e", "require('expo/scripts/resolveAppEntry')", projectRoot, "android", "absolute"].execute(null, rootDir).text.trim())
+}
+
 android {
     namespace "com.yourco.driverAA"
     compileSdk 34

--- a/driver-app/metro.config.js
+++ b/driver-app/metro.config.js
@@ -1,3 +1,3 @@
-const { getDefaultConfig, mergeConfig } = require('@react-native/metro-config');
-const defaultConfig = getDefaultConfig(__dirname);
-module.exports = mergeConfig(defaultConfig, {});
+const { getDefaultConfig } = require('expo/metro-config');
+const config = getDefaultConfig(__dirname);
+module.exports = config;


### PR DESCRIPTION
## Summary
- use Expo metro config in driver-app
- configure Gradle to bundle with `expo export:embed`
- streamline Android release workflow and clean old assets before assemble

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68afe13d3e18832e94b9ae42bcdae83e