### PR TITLE
feat(driver-app): configure splash and kotlin toolchain

### DIFF
--- a/driver-app/android/build.gradle
+++ b/driver-app/android/build.gradle
@@ -2,7 +2,7 @@ buildscript {
     dependencies {
         classpath("com.android.tools.build:gradle:8.4.2")
         classpath("com.google.gms:google-services:4.4.2")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.24")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${kotlinVersion}")
     }
 }
 
@@ -11,4 +11,12 @@ allprojects {
         google()
         mavenCentral()
     }
+}
+
+subprojects {
+  plugins.withId("org.jetbrains.kotlin.android") {
+    kotlin {
+      jvmToolchain(17)
+    }
+  }
 }

--- a/driver-app/android/gradle.properties
+++ b/driver-app/android/gradle.properties
@@ -1,0 +1,1 @@
+kotlinVersion=2.0.0

--- a/driver-app/app.config.ts
+++ b/driver-app/app.config.ts
@@ -14,17 +14,33 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     googleServicesFile: "./google-services.json",
     permissions: ["POST_NOTIFICATIONS"],
     versionCode: 2,
+    splash: {
+      image: "./assets/splash.png",
+      backgroundColor: "#FFFFFF",
+      resizeMode: "contain",
+    },
   },
 
   // plugins we rely on
   plugins: [
-    ["expo-splash-screen", { backgroundColor: "#FFFFFF", resizeMode: "contain" }],
+    [
+      "expo-splash-screen",
+      {
+        image: "./assets/splash.png",
+        backgroundColor: "#FFFFFF",
+        resizeMode: "contain",
+      },
+    ],
     "@react-native-firebase/app",
     "@react-native-firebase/messaging",
   ],
 
   // optional mirror (plugin reads it too)
-  splash: { backgroundColor: "#FFFFFF", resizeMode: "contain" },
+  splash: {
+    image: "./assets/splash.png",
+    backgroundColor: "#FFFFFF",
+    resizeMode: "contain",
+  },
 
   // backend URL for the app
   extra: {


### PR DESCRIPTION
## Summary
- reference splash image for Expo and Android
- pin Kotlin 2.0.0 and enforce JVM 17 toolchain

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68afe78550b8832e88f95a2219be85cc