### PR TITLE
chore(android): enforce Kotlin JVM 17 compile options

### DIFF
--- a/driver-app/android/app/build.gradle
+++ b/driver-app/android/app/build.gradle
@@ -25,6 +25,14 @@ android {
         versionCode 1
         versionName "1.0"
     }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
+    }
+    kotlinOptions {
+        jvmTarget = "17"
+    }
 }
 
 dependencies {

--- a/driver-app/android/build.gradle
+++ b/driver-app/android/build.gradle
@@ -19,4 +19,16 @@ subprojects {
       jvmToolchain(17)
     }
   }
+
+  // Enforce Kotlin compile options for ALL Kotlin tasks (including transitive modules)
+  tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+    kotlinOptions {
+      // Align with Java 17 toolchain; avoids mismatched target errors in subprojects
+      jvmTarget = "17"
+      // Compatibility default methods for interfaces (safe for Android/Expo libs)
+      freeCompilerArgs += ["-Xjvm-default=all-compatibility"]
+      // (Optional) help with some kapt/worker edge cases on CI:
+      // freeCompilerArgs += ["-Xuse-k2"]
+    }
+  }
 }

--- a/driver-app/android/gradle.properties
+++ b/driver-app/android/gradle.properties
@@ -1,1 +1,10 @@
 kotlinVersion=2.0.0
+org.gradle.jvmargs=-Xmx4096m -Dfile.encoding=UTF-8
+# Make Kotlin daemon memory explicit too
+kotlin.daemon.jvmargs=-Xmx2048m
+# Ensure Kotlin/JVM target matches Java toolchain
+kotlin.compiler.jvmTarget=17
+# Prefer daemon execution for Kotlin compiles in CI
+kotlin.compiler.execution.strategy=daemon
+# (Optional) keep Kotlin incremental builds on for faster repeats
+kotlin.incremental=true


### PR DESCRIPTION
## Summary
- configure Gradle JVM and Kotlin compiler memory settings
- enforce Kotlin compile options across subprojects
- target Java 17 in app module compile options

## Testing
- `./driver-app/node_modules/@react-native/gradle-plugin/gradlew -p driver-app/android tasks` *(fails: Could not resolve all files for configuration ':classpath')*

------
https://chatgpt.com/codex/tasks/task_b_68afea0e59c4832ebd3edc626fb7617e