### PR TITLE
chore(driver-android): enforce Kotlin 2 JVM 17 settings

### DIFF
--- a/.github/workflows/driver-android-release.yml
+++ b/.github/workflows/driver-android-release.yml
@@ -127,6 +127,9 @@ jobs:
       - name: Clean old Android assets (optional)
         working-directory: driver-app
         run: rm -rf android/app/src/main/assets android/app/src/main/res/drawable-*/node_modules*
+      - name: Kotlin compile diagnostic (non-fatal)
+        working-directory: driver-app/android
+        run: ./gradlew :expo-modules-core:compileReleaseKotlin --stacktrace --info || true
       - name: Build release APK
         if: steps.gradle_check.outputs.found == 'true'
         working-directory: driver-app/android

--- a/driver-app/android/build.gradle
+++ b/driver-app/android/build.gradle
@@ -13,6 +13,7 @@ allprojects {
     }
 }
 
+// Ensure every Kotlin Android subproject compiles with JVM 17
 subprojects {
   plugins.withId("org.jetbrains.kotlin.android") {
     kotlin {
@@ -29,6 +30,16 @@ subprojects {
       freeCompilerArgs += ["-Xjvm-default=all-compatibility"]
       // (Optional) help with some kapt/worker edge cases on CI:
       // freeCompilerArgs += ["-Xuse-k2"]
+    }
+  }
+
+  // Stop transitive Kotlin mismatches (some libs bring 1.8/1.9)
+  configurations.all {
+    resolutionStrategy {
+      force "org.jetbrains.kotlin:kotlin-stdlib:2.0.0"
+      force "org.jetbrains.kotlin:kotlin-stdlib-jdk7:2.0.0"
+      force "org.jetbrains.kotlin:kotlin-stdlib-jdk8:2.0.0"
+      force "org.jetbrains.kotlin:kotlin-reflect:2.0.0"
     }
   }
 }

--- a/driver-app/android/gradle.properties
+++ b/driver-app/android/gradle.properties
@@ -1,10 +1,18 @@
+# --- Kotlin/Gradle stability for Expo SDK 52 / RN 0.75 ---
+# Kotlin toolchain & compiler
 kotlinVersion=2.0.0
-org.gradle.jvmargs=-Xmx4096m -Dfile.encoding=UTF-8
-# Make Kotlin daemon memory explicit too
-kotlin.daemon.jvmargs=-Xmx2048m
-# Ensure Kotlin/JVM target matches Java toolchain
 kotlin.compiler.jvmTarget=17
-# Prefer daemon execution for Kotlin compiles in CI
-kotlin.compiler.execution.strategy=daemon
-# (Optional) keep Kotlin incremental builds on for faster repeats
 kotlin.incremental=true
+kotlin.code.style=official
+# Prefer daemon; Workers sometimes hide compiler errors in CI
+kotlin.compiler.execution.strategy=daemon
+kotlin.daemon.jvmargs=-Xmx2048m
+
+# Gradle JVM and memory
+org.gradle.jvmargs=-Xmx4096m -Dfile.encoding=UTF-8
+org.gradle.parallel=true
+# Keep configuration cache OFF with Kotlin 2.x + AGP until stable
+org.gradle.configuration-cache=false
+
+# (Optional) reduce flakiness on small runners
+org.gradle.workers.max=2


### PR DESCRIPTION
## Summary
- standardize Kotlin/Gradle properties for Expo SDK 52 with JVM 17
- force Kotlin 2.0 and JVM 17 compile options across all subprojects
- add Kotlin compile diagnostic step in Android release workflow

## Testing
- `gradle help` *(fails: Could not resolve all artifacts for configuration 'classpath')*

------
https://chatgpt.com/codex/tasks/task_b_68aff2982f40832eb7d8e728a82b8581