### PR TITLE
chore(android): upgrade RN gradle plugin

### DIFF
--- a/driver-app/android/app/build.gradle
+++ b/driver-app/android/app/build.gradle
@@ -2,14 +2,16 @@ plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
     id("com.google.gms.google-services")
+    // RN Gradle plugin (reads version from node_modules and sets RN minor = 75)
+    id("com.facebook.react")
 }
 
+// Use Expo CLI bundler for release (export:embed)
 react {
-    // Resolve @expo/cli path for Gradle
+    // Resolve @expo/cli so Gradle invokes Expo’s bundler
     cliFile = new File(["node", "--print", "require.resolve('@expo/cli')"].execute(null, rootDir).text.trim())
-    // Use the Expo export bundler so assets/embedded bundle are created correctly
     bundleCommand = "export:embed"
-    // Resolve the entry file via Expo helper (works with index.js or App.tsx)
+    // Resolve entry file via Expo helper
     def projectRoot = rootDir.getAbsoluteFile().getParentFile().getAbsolutePath()
     entryFile = file(["node", "-e", "require('expo/scripts/resolveAppEntry')", projectRoot, "android", "absolute"].execute(null, rootDir).text.trim())
 }

--- a/driver-app/android/build.gradle
+++ b/driver-app/android/build.gradle
@@ -1,15 +1,12 @@
 buildscript {
+    repositories {
+        google()
+        mavenCentral()
+    }
     dependencies {
         classpath("com.android.tools.build:gradle:8.4.2")
         classpath("com.google.gms:google-services:4.4.2")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${kotlinVersion}")
-    }
-}
-
-allprojects {
-    repositories {
-        google()
-        mavenCentral()
     }
 }
 

--- a/driver-app/android/gradle.properties
+++ b/driver-app/android/gradle.properties
@@ -1,18 +1,21 @@
-# --- Kotlin/Gradle stability for Expo SDK 52 / RN 0.75 ---
-# Kotlin toolchain & compiler
+# --- React Native minor version override (forces expo-modules-core to pick rn75 sources)
+reactNativeMinorVersion=75
+
+# --- Kotlin/Gradle stability (keep if already set)
 kotlinVersion=2.0.0
 kotlin.compiler.jvmTarget=17
 kotlin.incremental=true
 kotlin.code.style=official
-# Prefer daemon; Workers sometimes hide compiler errors in CI
 kotlin.compiler.execution.strategy=daemon
 kotlin.daemon.jvmargs=-Xmx2048m
 
-# Gradle JVM and memory
+# Gradle JVM & memory
 org.gradle.jvmargs=-Xmx4096m -Dfile.encoding=UTF-8
 org.gradle.parallel=true
-# Keep configuration cache OFF with Kotlin 2.x + AGP until stable
 org.gradle.configuration-cache=false
 
 # (Optional) reduce flakiness on small runners
 org.gradle.workers.max=2
+
+# Hermes JS engine
+hermesEnabled=true

--- a/driver-app/android/settings.gradle
+++ b/driver-app/android/settings.gradle
@@ -1,0 +1,29 @@
+pluginManagement {
+  repositories {
+    gradlePluginPortal()
+    mavenCentral()
+    google()
+    // Let Gradle find the RN Android artifacts locally
+    maven { url("$rootDir/../node_modules/react-native/android") }
+  }
+    // Use the RN Gradle plugin from node_modules to ensure correct RN detection (minor=75)
+    includeBuild("../node_modules/@react-native/gradle-plugin")
+  }
+
+dependencyResolutionManagement {
+  repositoriesMode.set(RepositoriesMode.PREFER_SETTINGS)
+  repositories {
+    google()
+    mavenCentral()
+    // RN Android artifacts (react-android, hermes-android, etc.)
+    maven { url("$rootDir/../node_modules/react-native/android") }
+  }
+}
+
+rootProject.name = "driver-app"
+include(":app")
+
+// Autolink Expo modules
+apply from: new File(["node", "--print", "require.resolve('expo/scripts/autolinking.gradle')"].execute(null, rootDir).text.trim())
+useExpoModules()
+

--- a/driver-app/package-lock.json
+++ b/driver-app/package-lock.json
@@ -15,6 +15,7 @@
         "@react-native-firebase/auth": "^21.4.0",
         "@react-native-firebase/messaging": "^21.4.0",
         "@react-native-firebase/storage": "^21.4.0",
+        "@react-native/gradle-plugin": "^0.75.5",
         "@react-native/metro-config": "^0.74.0",
         "expo": "~52.0.0",
         "expo-image-manipulator": "^12.0.5",

--- a/driver-app/package.json
+++ b/driver-app/package.json
@@ -17,6 +17,7 @@
     "@react-native-firebase/auth": "^21.4.0",
     "@react-native-firebase/messaging": "^21.4.0",
     "@react-native-firebase/storage": "^21.4.0",
+    "@react-native/gradle-plugin": "^0.75.5",
     "@react-native/metro-config": "^0.74.0",
     "expo": "~52.0.0",
     "expo-image-manipulator": "^12.0.5",


### PR DESCRIPTION
## Summary
- ensure hermes JS engine and disable Gradle configuration cache
- source React Native Gradle plugin 0.75.5 and autolink Expo modules via settings.gradle
- bump `@react-native/gradle-plugin` dependency

## Testing
- `JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 gradle -p driver-app/android :expo-modules-core:compileReleaseKotlin --no-build-cache --console=plain` *(fails: trust store file /usr/lib/jvm/java-17-openjdk-amd64/lib/security/cacerts does not exist)*

------
https://chatgpt.com/codex/tasks/task_b_68aff6659220832ebf0246d145be8bb9