### PR TITLE
feat(driver-app): bootstrap expo skeleton and release workflow

### DIFF
--- a/.github/workflows/release-apk.yml
+++ b/.github/workflows/release-apk.yml
@@ -1,0 +1,32 @@
+name: Build Android Release APK
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+      - name: Install dependencies
+        run: |
+          cd driver-app
+          npm install
+      - name: Prebuild Android project
+        run: |
+          cd driver-app
+          npx expo prebuild -p android
+      - name: Build release APK
+        run: |
+          cd driver-app/android
+          ./gradlew assembleRelease
+      - name: Upload APK artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-release
+          path: driver-app/android/app/build/outputs/apk/release/app-release.apk

--- a/driver-app/app.config.ts
+++ b/driver-app/app.config.ts
@@ -1,0 +1,12 @@
+import { ExpoConfig } from "@expo/config";
+
+export default ({ config }: { config: ExpoConfig }): ExpoConfig => {
+  return {
+    ...config,
+    name: "DriverApp",
+    slug: "driver-app",
+    extra: {
+      API_BASE: process.env.EXPO_PUBLIC_API_BASE,
+    },
+  };
+};

--- a/driver-app/app/(tabs)/_layout.tsx
+++ b/driver-app/app/(tabs)/_layout.tsx
@@ -1,0 +1,10 @@
+import { Tabs } from "expo-router";
+
+export default function TabsLayout() {
+  return (
+    <Tabs>
+      <Tabs.Screen name="index" options={{ title: "Active" }} />
+      <Tabs.Screen name="completed" options={{ title: "Completed" }} />
+    </Tabs>
+  );
+}

--- a/driver-app/app/(tabs)/completed.tsx
+++ b/driver-app/app/(tabs)/completed.tsx
@@ -1,0 +1,13 @@
+import { View, Text } from "react-native";
+import { useOrders } from "../../src/presentation/hooks/useOrders";
+
+export default function CompletedTab() {
+  const { completed } = useOrders();
+  return (
+    <View>
+      {completed.map((o) => (
+        <Text key={o.id}>Order #{o.id} - {o.customer.name}</Text>
+      ))}
+    </View>
+  );
+}

--- a/driver-app/app/(tabs)/index.tsx
+++ b/driver-app/app/(tabs)/index.tsx
@@ -1,0 +1,16 @@
+import { View, Text } from "react-native";
+import { Link } from "expo-router";
+import { useOrders } from "../../src/presentation/hooks/useOrders";
+
+export default function ActiveTab() {
+  const { active } = useOrders();
+  return (
+    <View>
+      {active.map((o) => (
+        <Link key={o.id} href={`/order/${o.id}`}>
+          <Text>Order #{o.id} - {o.customer.name}</Text>
+        </Link>
+      ))}
+    </View>
+  );
+}

--- a/driver-app/app/_layout.tsx
+++ b/driver-app/app/_layout.tsx
@@ -1,0 +1,16 @@
+import { Slot } from "expo-router";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { SafeAreaView, StatusBar } from "react-native";
+
+const queryClient = new QueryClient();
+
+export default function RootLayout() {
+  return (
+    <QueryClientProvider client={queryClient}>
+      <SafeAreaView style={{ flex: 1 }}>
+        <StatusBar />
+        <Slot />
+      </SafeAreaView>
+    </QueryClientProvider>
+  );
+}

--- a/driver-app/app/commissions/index.tsx
+++ b/driver-app/app/commissions/index.tsx
@@ -1,0 +1,9 @@
+import { View, Text } from "react-native";
+
+export default function CommissionsScreen() {
+  return (
+    <View>
+      <Text>Commission summary coming soon</Text>
+    </View>
+  );
+}

--- a/driver-app/app/order/[id].tsx
+++ b/driver-app/app/order/[id].tsx
@@ -1,0 +1,21 @@
+import { View, Text } from "react-native";
+import { useLocalSearchParams } from "expo-router";
+import { useOrders } from "../../src/presentation/hooks/useOrders";
+
+export default function OrderDetail() {
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const { active, completed } = useOrders();
+  const order = [...active, ...completed].find((o) => o.id.toString() === id);
+
+  if (!order) {
+    return <Text>Order not found</Text>;
+  }
+
+  return (
+    <View>
+      <Text>Order #{order.id}</Text>
+      <Text>Status: {order.status}</Text>
+      <Text>Customer: {order.customer.name}</Text>
+    </View>
+  );
+}

--- a/driver-app/package.json
+++ b/driver-app/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "driver-app",
+  "version": "0.1.0",
+  "private": true,
+  "main": "expo-router/entry",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo run:android",
+    "test": "jest --passWithNoTests"
+  },
+  "dependencies": {
+    "expo": "^52.0.0",
+    "expo-router": "^3.0.0",
+    "react": "18.2.0",
+    "react-native": "0.76.0",
+    "@tanstack/react-query": "^5.0.0",
+    "@react-native-async-storage/async-storage": "^2.0.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.0",
+    "@types/react-native": "^0.72.0",
+    "typescript": "^5.0.0",
+    "jest": "^29.0.0",
+    "ts-jest": "^29.0.0"
+  }
+}

--- a/driver-app/src/core/entities/Order.ts
+++ b/driver-app/src/core/entities/Order.ts
@@ -1,0 +1,24 @@
+export type ISODateString = string;
+export type Cents = number;
+
+export enum OrderStatus {
+  ASSIGNED = "ASSIGNED",
+  IN_TRANSIT = "IN_TRANSIT",
+  ON_HOLD = "ON_HOLD",
+  DELIVERED = "DELIVERED",
+  CANCELLED = "CANCELLED",
+}
+
+export interface Customer {
+  id: number;
+  name: string;
+  phone: string;
+  address: string;
+  mapUrl?: string;
+}
+
+export interface Order {
+  id: number;
+  status: OrderStatus;
+  customer: Customer;
+}

--- a/driver-app/src/presentation/hooks/useOrders.ts
+++ b/driver-app/src/presentation/hooks/useOrders.ts
@@ -1,0 +1,22 @@
+import { useState } from "react";
+import { Order, OrderStatus } from "../../core/entities/Order";
+
+const seed: Order[] = [
+  {
+    id: 1,
+    status: OrderStatus.ASSIGNED,
+    customer: { id: 1, name: "Alice", phone: "123", address: "123 Street" },
+  },
+  {
+    id: 2,
+    status: OrderStatus.DELIVERED,
+    customer: { id: 2, name: "Bob", phone: "456", address: "456 Avenue" },
+  },
+];
+
+export function useOrders() {
+  const [orders] = useState(seed);
+  const active = orders.filter((o) => o.status !== OrderStatus.DELIVERED);
+  const completed = orders.filter((o) => o.status === OrderStatus.DELIVERED);
+  return { active, completed };
+}

--- a/driver-app/src/shared/constants/config.ts
+++ b/driver-app/src/shared/constants/config.ts
@@ -1,0 +1,11 @@
+import Constants from "expo-constants";
+
+export const API_BASE = (() => {
+  const fromEnv = process.env.EXPO_PUBLIC_API_BASE;
+  const fromConfig = (Constants.expoConfig?.extra as any)?.API_BASE;
+  const value = fromEnv ?? fromConfig;
+  if (!value) {
+    throw new Error("API_BASE is not set");
+  }
+  return value as string;
+})();

--- a/driver-app/tsconfig.json
+++ b/driver-app/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "expo/tsconfig.base",
+  "compilerOptions": {
+    "strict": true,
+    "baseUrl": "."
+  },
+  "include": ["app", "src"]
+}


### PR DESCRIPTION
## Summary
- scaffold Expo driver app with tab navigation, order detail screen, and config loader
- add React Query provider and seeded hooks for order lists
- add GitHub Actions workflow to build Android release APK

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b096bd33a4832e8b18a925721516f9