### PR TITLE
feat(driver-app): add driver scheme and event bus

### DIFF
--- a/driver-app/app.config.ts
+++ b/driver-app/app.config.ts
@@ -1,11 +1,11 @@
 import { ExpoConfig } from "@expo/config";
 
 export default ({ config }: { config: ExpoConfig }): ExpoConfig => {
-  const apiBase = process.env.API_BASE || process.env.EXPO_PUBLIC_API_BASE;
   return {
     ...config,
     name: "DriverApp",
     slug: "driver-app",
+    scheme: "driver",
     plugins: [
       ...(config.plugins ?? []),
       "@react-native-firebase/app",
@@ -13,7 +13,7 @@ export default ({ config }: { config: ExpoConfig }): ExpoConfig => {
       "@notifee/react-native",
     ],
     extra: {
-      API_BASE: apiBase,
+      API_BASE: process.env.API_BASE || process.env.EXPO_PUBLIC_API_BASE,
     },
   };
 };

--- a/driver-app/src/infrastructure/events/bus.ts
+++ b/driver-app/src/infrastructure/events/bus.ts
@@ -1,27 +1,27 @@
-export type Listener<T = any> = (payload: T) => void;
+type Listener = (payload: any) => void;
 
 const listeners = new Map<string, Set<Listener>>();
 
-export function on<T = any>(event: string, listener: Listener<T>) {
+export function on(event: string, fn: Listener) {
   if (!listeners.has(event)) {
     listeners.set(event, new Set());
   }
-  listeners.get(event)!.add(listener as Listener);
-  return () => off(event, listener);
+  listeners.get(event)!.add(fn);
+  return () => off(event, fn);
 }
 
-export function off(event: string, listener: Listener) {
+export function off(event: string, fn: Listener) {
   const set = listeners.get(event);
   if (!set) return;
-  set.delete(listener);
+  set.delete(fn);
   if (set.size === 0) listeners.delete(event);
 }
 
-export function emit<T = any>(event: string, payload: T) {
+export function emit(event: string, payload: any) {
   const set = listeners.get(event);
   if (!set) return;
-  for (const listener of Array.from(set)) {
-    listener(payload);
+  for (const fn of set) {
+    fn(payload);
   }
 }
 


### PR DESCRIPTION
## Summary
- add `driver` deep link scheme and API base passthrough to config
- streamline event bus for order navigation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b0eba865e4832e8e242b382c1f84d4