### PR TITLE
chore(driver-app): wire firebase & local dev

### DIFF
--- a/driver-app/.gitignore
+++ b/driver-app/.gitignore
@@ -1,3 +1,4 @@
 android/app/google-services.json
-.env*
+.env
+.env.*
 

--- a/driver-app/README_DEV.md
+++ b/driver-app/README_DEV.md
@@ -1,9 +1,8 @@
 # Local Android Development
 
-1. Copy `android/app/google-services.json.example` to `android/app/google-services.json`.
-2. Set `API_BASE` in `.env` or provide it on the CLI when running commands.
-3. Install dependencies with `npm ci`.
-4. Generate native Android project: `npx expo prebuild --platform android`.
-5. Build and run:
-   - `cd android && ./gradlew assembleDebug`, or
-   - `npm run android`.
+1) Copy `android/app/google-services.json.example` → `android/app/google-services.json`
+2) Set `API_BASE` via `.env` or CLI
+3) `npm ci`
+4) `npx expo prebuild --platform android`
+5) `cd android && ./gradlew assembleDebug` or `npm run android`
+

--- a/driver-app/android/app/google-services.json.example
+++ b/driver-app/android/app/google-services.json.example
@@ -1,6 +1,6 @@
-// Example google-services.json - copy to android/app/google-services.json and replace with your Firebase config
 {
-  "project_info": {
-    "project_id": "your-project-id"
-  }
+  "//": "Copy this file to android/app/google-services.json for local dev.",
+  "project_info": { "project_id": "your-project-id" },
+  "client": [ { "client_info": { "mobilesdk_app_id": "1:123:android:abc" } } ]
 }
+

--- a/driver-app/src/infrastructure/firebase/background-handler.ts
+++ b/driver-app/src/infrastructure/firebase/background-handler.ts
@@ -1,5 +1,5 @@
 import messaging from "@react-native-firebase/messaging";
-// Register a headless handler for background messages
+
 messaging().setBackgroundMessageHandler(async (message) => {
-  // Optionally: prefetch orders or store a flag for UI invalidation
+  // noop or TODO: prefetch orders
 });


### PR DESCRIPTION
## Summary
- register FCM background handler and load at boot
- ignore env and google-services config and provide example
- document local Android dev setup

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_b_68b0ecc63078832e9494a0dd391a0307