### PR TITLE
feat: harden network and data layers

### DIFF
--- a/driver-app/__tests__/unit/order-mapping.test.ts
+++ b/driver-app/__tests__/unit/order-mapping.test.ts
@@ -1,23 +1,56 @@
-import { ApiOrderSchema, mapOrder } from '@infra/api/schemas';
+import { ApiOrderSchema } from '@infra/api/schemas';
 import { OrderStatus } from '@core/entities/Order';
+
+jest.mock('@react-native-firebase/auth', () => ({
+  __esModule: true,
+  default: () => ({ currentUser: null }),
+}));
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  __esModule: true,
+  default: {
+    getItem: jest.fn(),
+    setItem: jest.fn(),
+    removeItem: jest.fn(),
+  },
+}));
+
+jest.mock('@shared/constants/config', () => ({ API_BASE: '' }));
+
+jest.mock('@infra/api/ApiClient', () => ({
+  __esModule: true,
+  default: {
+    get: jest.fn(),
+    post: jest.fn(),
+    patch: jest.fn(),
+    upload: jest.fn(),
+  },
+}));
+
+const { mapApiOrder } = require('@infra/api/OrderRepository');
 
 describe('order mapping', () => {
   test('parses and maps to domain', () => {
     const api = ApiOrderSchema.parse({
       id: 1,
+      code: 'X',
       status: OrderStatus.ASSIGNED,
+      delivery_date: '2024-01-01',
       customer: {
         id: 2,
         name: 'John Doe',
         phone: '123',
         address: 'Street',
-        mapUrl: 'url',
+        map_url: 'url',
       },
+      pricing: { total_cents: 1000 },
     });
-    const order = mapOrder(api);
+    const order = mapApiOrder(api);
     expect(order).toEqual({
       id: 1,
+      code: 'X',
       status: OrderStatus.ASSIGNED,
+      deliveryDate: '2024-01-01',
       customer: {
         id: 2,
         name: 'John Doe',
@@ -25,6 +58,7 @@ describe('order mapping', () => {
         address: 'Street',
         mapUrl: 'url',
       },
+      pricing: { total_cents: 1000 },
     });
   });
 });

--- a/driver-app/src/core/entities/Order.ts
+++ b/driver-app/src/core/entities/Order.ts
@@ -19,6 +19,11 @@ export interface Customer {
 
 export interface Order {
   id: number;
+  code: string;
   status: OrderStatus;
+  deliveryDate: ISODateString;
   customer: Customer;
+  pricing: {
+    total_cents: Cents;
+  };
 }

--- a/driver-app/src/infrastructure/api/schemas.ts
+++ b/driver-app/src/infrastructure/api/schemas.ts
@@ -1,28 +1,28 @@
 import { z } from 'zod';
-import { Order, OrderStatus } from '@core/entities/Order';
+import { OrderStatus } from '@core/entities/Order';
 
 export const ApiCustomerSchema = z.object({
   id: z.number(),
   name: z.string(),
   phone: z.string(),
   address: z.string(),
-  mapUrl: z.string().optional(),
+  map_url: z.string().optional(),
+});
+
+export const ApiPricingSchema = z.object({
+  total_cents: z.number(),
 });
 
 export const ApiOrderSchema = z.object({
   id: z.number(),
+  code: z.string(),
   status: z.nativeEnum(OrderStatus),
+  delivery_date: z.string(),
   customer: ApiCustomerSchema,
+  pricing: ApiPricingSchema,
 });
-
-export type ApiOrder = z.infer<typeof ApiOrderSchema>;
 
 export const ApiOrderListSchema = z.array(ApiOrderSchema);
 
-export function mapOrder(api: ApiOrder): Order {
-  return {
-    id: api.id,
-    status: api.status,
-    customer: api.customer,
-  };
-}
+export type ApiOrder = z.infer<typeof ApiOrderSchema>;
+export type ApiOrderList = z.infer<typeof ApiOrderListSchema>;

--- a/driver-app/src/infrastructure/firebase/NotificationService.ts
+++ b/driver-app/src/infrastructure/firebase/NotificationService.ts
@@ -1,15 +1,11 @@
 import messaging from "@react-native-firebase/messaging";
 import notifee, { EventType } from "@notifee/react-native";
-import { API_BASE } from "@shared/constants/config";
 import { emit } from "@infra/events/bus";
 import { ORDER_OPEN_EVENT } from "@infra/events/bus";
+import ApiClient from "@infra/api/ApiClient";
 
 async function postToken(token: string) {
-  await fetch(`${API_BASE}/drivers/devices`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ token }),
-  });
+  await ApiClient.post("/drivers/devices", { fcm_token: token });
 }
 
 export async function registerDevice() {

--- a/driver-app/src/infrastructure/storage/Outbox.ts
+++ b/driver-app/src/infrastructure/storage/Outbox.ts
@@ -45,7 +45,13 @@ export async function enqueue(job: OutboxJob): Promise<void> {
 }
 
 export async function getPending(): Promise<OutboxJob[]> {
-  return read();
+  const jobs = await read();
+  const now = Date.now();
+  return jobs.filter((j) => {
+    if (!j.lastAttempt) return true;
+    const delay = 2000 * Math.pow(2, j.retries) + Math.random() * 200;
+    return now - j.lastAttempt >= delay;
+  });
 }
 
 export async function markCompleted(id: string): Promise<void> {

--- a/driver-app/src/presentation/hooks/useOrders.ts
+++ b/driver-app/src/presentation/hooks/useOrders.ts
@@ -1,16 +1,27 @@
 import { useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { Order, OrderStatus } from "../../core/entities/Order";
+import {
+  updateStatus as repoUpdateStatus,
+  uploadProofOfDelivery as repoUploadProof,
+} from "@infra/api/OrderRepository";
 
 const seed: Order[] = [
   {
     id: 1,
+    code: "A1",
     status: OrderStatus.ASSIGNED,
+    deliveryDate: "2024-01-01",
     customer: { id: 1, name: "Alice", phone: "123", address: "123 Street" },
+    pricing: { total_cents: 0 },
   },
   {
     id: 2,
+    code: "B2",
     status: OrderStatus.DELIVERED,
+    deliveryDate: "2024-01-02",
     customer: { id: 2, name: "Bob", phone: "456", address: "456 Avenue" },
+    pricing: { total_cents: 0 },
   },
 ];
 
@@ -19,4 +30,27 @@ export function useOrders() {
   const active = orders.filter((o) => o.status !== OrderStatus.DELIVERED);
   const completed = orders.filter((o) => o.status === OrderStatus.DELIVERED);
   return { active, completed };
+}
+
+export function useOrderMutations() {
+  const queryClient = useQueryClient();
+  const invalidate = () => {
+    try {
+      queryClient.invalidateQueries({ queryKey: ["orders"] });
+    } catch {
+      // TODO: provide QueryClient for invalidation
+    }
+  };
+
+  const updateStatus = async (id: number | string, status: string) => {
+    await repoUpdateStatus(id, status);
+    invalidate();
+  };
+
+  const uploadProofOfDelivery = async (id: number | string, uri: string) => {
+    await repoUploadProof(id, uri);
+    invalidate();
+  };
+
+  return { updateStatus, uploadProofOfDelivery };
 }


### PR DESCRIPTION
## Summary
- enrich ApiClient with JSON headers, auth token, transient retry and FormData uploads
- validate & map orders with zod, backoff outbox, and authorize device registration
- expose order mutations with query invalidation and JPEG PoD uploads

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_b_68b0edf0cda4832e88ba535807523b7c