### PR TITLE
fix: improve release APK workflow

### DIFF
--- a/.github/workflows/release-apk.yml
+++ b/.github/workflows/release-apk.yml
@@ -7,9 +7,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      FIREBASE_ANDROID_APP_ID: ${{ secrets.FIREBASE_ANDROID_APP_ID }}
-      FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}
-      FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
       GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
       API_BASE: ${{ secrets.API_BASE }}
     defaults:
@@ -35,16 +32,18 @@ jobs:
         run: npm ci
       - name: Prebuild Android project
         run: npx expo prebuild --platform android --non-interactive --clean
-      - name: Set up google-services.json
-        if: ${{ secrets.GOOGLE_SERVICES_JSON != '' }}
-        env:
-          GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
-        run: echo "$GOOGLE_SERVICES_JSON" > android/app/google-services.json
       - name: Ensure android project generated
         run: test -d android || exit 1
+      - name: Ensure gradlew exists
+        run: test -f android/gradlew || (echo "missing gradlew" && exit 1)
+      - name: Set up google-services.json
+        if: ${{ env.GOOGLE_SERVICES_JSON != '' }}
+        run: echo "$GOOGLE_SERVICES_JSON" > android/app/google-services.json
       - name: Build release APK
-        working-directory: android
-        run: ./gradlew assembleRelease
+        run: |
+          cd android
+          chmod +x gradlew
+          ./gradlew assembleRelease
       - name: Upload APK artifact
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary
- ensure android project and gradlew exist before building the release APK
- move google-services setup after prebuild and run gradle with explicit chmod
- streamline workflow env by removing unused Firebase variables
- use env context to conditionally write google-services.json

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b0f3ea748c832ea06123d21d9b9075