### PR TITLE
fix: sync driver app lock file

### DIFF
--- a/driver-app/package-lock.json
+++ b/driver-app/package-lock.json
@@ -17,7 +17,8 @@
         "expo": "^52.0.0",
         "expo-router": "^3.0.0",
         "react": "18.2.0",
-        "react-native": "0.76.0"
+        "react-native": "0.76.0",
+        "zod": "^3.23.8"
       },
       "devDependencies": {
         "@types/jest": "^29.0.0",
@@ -14709,6 +14710,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }


### PR DESCRIPTION
## Summary
- sync driver-app package-lock.json to include zod dependency

## Testing
- `npm ci`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b0f7042838832ea330fc73a253837f