### PR TITLE
feat(driver-app): inline API env vars

### DIFF
--- a/.github/workflows/release-apk.yml
+++ b/.github/workflows/release-apk.yml
@@ -7,8 +7,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
       API_BASE: ${{ secrets.API_BASE }}
+      FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}
+      EXPO_NO_TELEMETRY: 1
+      NODE_ENV: production
+      CI: true
     defaults:
       run:
         working-directory: driver-app
@@ -36,8 +39,12 @@ jobs:
       - name: Ensure gradlew exists
         run: test -f android/gradlew || (echo "missing gradlew" && exit 1)
       - name: Set up google-services.json
-        if: ${{ env.GOOGLE_SERVICES_JSON != '' }}
-        run: echo "$GOOGLE_SERVICES_JSON" > android/app/google-services.json
+        if: ${{ secrets.GOOGLE_SERVICES_JSON != '' }}
+        run: echo "${{ secrets.GOOGLE_SERVICES_JSON }}" > android/app/google-services.json
+      - name: Print API_BASE for Metro
+        run: |
+          echo "API_BASE=$API_BASE"
+          node -e "console.log('Node sees API_BASE:', process.env.API_BASE || 'UNSET')"
       - name: Build release APK
         run: |
           cd android

--- a/driver-app/app.config.ts
+++ b/driver-app/app.config.ts
@@ -1,19 +1,10 @@
 import { ExpoConfig } from "@expo/config";
-import fs from "fs";
-import path from "path";
 
 export default ({ config }: { config: ExpoConfig }): ExpoConfig => {
-  const googleServices = process.env.GOOGLE_SERVICES_JSON;
   const android: ExpoConfig["android"] = {
     ...config.android,
     package: "com.yourco.driverAA",
   };
-
-  if (googleServices) {
-    const googleServicesPath = path.resolve(__dirname, "google-services.json");
-    fs.writeFileSync(googleServicesPath, Buffer.from(googleServices, "base64"));
-    android.googleServicesFile = "./google-services.json";
-  }
 
   return {
     ...config,
@@ -27,7 +18,8 @@ export default ({ config }: { config: ExpoConfig }): ExpoConfig => {
       "@notifee/react-native",
     ],
     extra: {
-      API_BASE: process.env.API_BASE || process.env.EXPO_PUBLIC_API_BASE,
+      API_BASE: process.env.API_BASE,
+      FIREBASE_PROJECT_ID: process.env.FIREBASE_PROJECT_ID,
     },
     android,
   };

--- a/driver-app/babel.config.js
+++ b/driver-app/babel.config.js
@@ -1,0 +1,26 @@
+module.exports = function (api) {
+  api.cache(true);
+  return {
+    presets: ["babel-preset-expo"],
+    plugins: [
+      [
+        "module-resolver",
+        {
+          root: ["./"],
+          alias: {
+            "@core": "./src/core",
+            "@infra": "./src/infrastructure",
+            "@presentation": "./src/presentation",
+            "@shared": "./src/shared",
+          },
+        },
+      ],
+      [
+        "@babel/plugin-transform-inline-environment-variables",
+        {
+          include: ["API_BASE", "FIREBASE_PROJECT_ID"],
+        },
+      ],
+    ],
+  };
+};

--- a/driver-app/package-lock.json
+++ b/driver-app/package-lock.json
@@ -21,9 +21,11 @@
         "zod": "^3.23.8"
       },
       "devDependencies": {
+        "@babel/plugin-transform-inline-environment-variables": "npm:babel-plugin-transform-inline-environment-variables@^0.4.4",
         "@types/jest": "^29.0.0",
         "@types/react": "^18.2.0",
         "@types/react-native": "^0.72.0",
+        "babel-plugin-module-resolver": "^5.0.2",
         "jest": "^29.0.0",
         "ts-jest": "^29.0.0",
         "typescript": "^5.0.0"
@@ -1347,6 +1349,14 @@
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
       }
+    },
+    "node_modules/@babel/plugin-transform-inline-environment-variables": {
+      "name": "babel-plugin-transform-inline-environment-variables",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-inline-environment-variables/-/babel-plugin-transform-inline-environment-variables-0.4.4.tgz",
+      "integrity": "sha512-bJILBtn5a11SmtR2j/3mBOjX4K3weC6cq+NNZ7hG22wCAqpc3qtj/iN7dSe9HDiS46lgp1nHsQgeYrea/RUe+g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/plugin-transform-json-strings": {
       "version": "7.27.1",
@@ -5597,6 +5607,75 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/babel-plugin-module-resolver": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-module-resolver/-/babel-plugin-module-resolver-5.0.2.tgz",
+      "integrity": "sha512-9KtaCazHee2xc0ibfqsDeamwDps6FZNo5S0Q81dUqEuFzVwPhcT4J5jOqIVvgCA3Q/wO9hKYxN/Ds3tIsp5ygg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-babel-config": "^2.1.1",
+        "glob": "^9.3.3",
+        "pkg-up": "^3.1.0",
+        "reselect": "^4.1.7",
+        "resolve": "^1.22.8"
+      }
+    },
+    "node_modules/babel-plugin-module-resolver/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/babel-plugin-module-resolver/node_modules/glob": {
+      "version": "9.3.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-9.3.5.tgz",
+      "integrity": "sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "minimatch": "^8.0.2",
+        "minipass": "^4.2.4",
+        "path-scurry": "^1.6.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/babel-plugin-module-resolver/node_modules/minimatch": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.4.tgz",
+      "integrity": "sha512-W0Wvr9HyFXZRGIDgCicunpQ299OKXs9RgZfaukz4qAW/pJhcpUfupc9c+OObPOFueNy8VSrZgEmDtk6Kh4WzDA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/babel-plugin-module-resolver/node_modules/minipass": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
+      "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/babel-plugin-polyfill-corejs2": {
       "version": "0.4.14",
       "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.14.tgz",
@@ -8099,6 +8178,16 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
+    },
+    "node_modules/find-babel-config": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/find-babel-config/-/find-babel-config-2.1.2.tgz",
+      "integrity": "sha512-ZfZp1rQyp4gyuxqt1ZqjFGVeVBvmpURMqdIWXbPRfB97Bf6BzdK/xSIbylEINzQ0kB5tlDQfn9HkNXXWsqTqLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json5": "^2.2.3"
+      }
     },
     "node_modules/find-cache-dir": {
       "version": "2.1.0",
@@ -11852,6 +11941,85 @@
         "node": ">=4"
       }
     },
+    "node_modules/pkg-up": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-3.1.0.tgz",
+      "integrity": "sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-up/node_modules/find-up": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pkg-up/node_modules/locate-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pkg-up/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pkg-up/node_modules/p-locate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pkg-up/node_modules/path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/plist": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/plist/-/plist-3.1.0.tgz",
@@ -12592,6 +12760,13 @@
       "dependencies": {
         "path-parse": "^1.0.5"
       }
+    },
+    "node_modules/reselect": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.8.tgz",
+      "integrity": "sha512-ab9EmR80F/zQTMNeneUr4cv+jSwPJgIlvEmVwLerwrWVbpLlBuls9XHzIeTFy4cegU2NHBp3va0LKOzU5qFEYQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.10",

--- a/driver-app/package.json
+++ b/driver-app/package.json
@@ -10,24 +10,26 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "expo": "^52.0.0",
-    "expo-router": "^3.0.0",
-    "react": "18.2.0",
-    "react-native": "0.76.0",
-    "@tanstack/react-query": "^5.0.0",
+    "@notifee/react-native": "^6.0.0",
     "@react-native-async-storage/async-storage": "^2.0.0",
     "@react-native-firebase/app": "^19.0.0",
     "@react-native-firebase/auth": "^19.0.0",
     "@react-native-firebase/messaging": "^19.0.0",
-    "@notifee/react-native": "^6.0.0",
+    "@tanstack/react-query": "^5.0.0",
+    "expo": "^52.0.0",
+    "expo-router": "^3.0.0",
+    "react": "18.2.0",
+    "react-native": "0.76.0",
     "zod": "^3.23.8"
   },
   "devDependencies": {
+    "@babel/plugin-transform-inline-environment-variables": "npm:babel-plugin-transform-inline-environment-variables@^0.4.4",
+    "@types/jest": "^29.0.0",
     "@types/react": "^18.2.0",
     "@types/react-native": "^0.72.0",
-    "@types/jest": "^29.0.0",
-    "typescript": "^5.0.0",
+    "babel-plugin-module-resolver": "^5.0.2",
     "jest": "^29.0.0",
-    "ts-jest": "^29.0.0"
+    "ts-jest": "^29.0.0",
+    "typescript": "^5.0.0"
   }
 }

--- a/driver-app/readme throwaway
+++ b/driver-app/readme throwaway
@@ -298,7 +298,7 @@ If server API absent, compute client-side with a single function calcCommission(
 
 API_BASE must be resolvable from:
 
-EXPO_PUBLIC_API_BASE env, or
+API_BASE env, or
 
 app.config.ts -> extra.API_BASE
 
@@ -324,7 +324,7 @@ Add Commission query/screen.
 
 13) Verification Checklist (linkages)
 
- EXPO_PUBLIC_API_BASE set → app boots; missing → friendly error.
+ API_BASE set → app boots; missing → friendly error.
 
  GET /drivers/orders returns → Active & Completed show correct items.
 

--- a/driver-app/src/shared/constants/config.ts
+++ b/driver-app/src/shared/constants/config.ts
@@ -1,16 +1,27 @@
 import Constants from "expo-constants";
 
-// Resolve API_BASE from environment variables or Expo config in order of precedence.
 export const API_BASE = (() => {
   const fromEnv = process.env.API_BASE;
-  const fromExpoPublic = process.env.EXPO_PUBLIC_API_BASE;
-  const fromConfig = (Constants.expoConfig?.extra as any)?.API_BASE;
-  const value = fromEnv ?? fromExpoPublic ?? fromConfig;
+  const fromConfig =
+    (Constants.expoConfig?.extra as any)?.API_BASE ??
+    (Constants.manifest?.extra as any)?.API_BASE;
+  const value = fromEnv ?? fromConfig;
+
   if (!value) {
-    throw new Error(
-      "API_BASE is not configured. Set API_BASE or EXPO_PUBLIC_API_BASE in your environment or app.config.ts"
-    );
+    if (__DEV__) {
+      console.warn(
+        "API_BASE missing; set API_BASE in CI or app.config.ts extra."
+      );
+    }
+    return "https://__MISSING_API_BASE__";
   }
-  return value as string;
+  return String(value);
 })();
 
+export const FIREBASE_PROJECT_ID = (() => {
+  const envVal = process.env.FIREBASE_PROJECT_ID;
+  const cfgVal =
+    (Constants.expoConfig?.extra as any)?.FIREBASE_PROJECT_ID ??
+    (Constants.manifest?.extra as any)?.FIREBASE_PROJECT_ID;
+  return String(envVal ?? cfgVal ?? "");
+})();


### PR DESCRIPTION
## Summary
- inline `API_BASE` and `FIREBASE_PROJECT_ID` at bundle time via Babel plugin with module aliases
- expose API base in `app.config.ts` without `EXPO_PUBLIC_*` and make constants warn instead of throw
- pass API env vars directly in Android release workflow and print them for sanity

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_b_68b10f220d90832eb49e8ff237c83cb8