### PR TITLE
fix(ci): reference env vars in release APK workflow

### DIFF
--- a/.github/workflows/release-apk.yml
+++ b/.github/workflows/release-apk.yml
@@ -7,8 +7,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      API_BASE: ${{ secrets.API_BASE }}
-      FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}
       EXPO_NO_TELEMETRY: 1
       NODE_ENV: production
       CI: true
@@ -39,8 +37,8 @@ jobs:
       - name: Ensure gradlew exists
         run: test -f android/gradlew || (echo "missing gradlew" && exit 1)
       - name: Set up google-services.json
-        if: ${{ secrets.GOOGLE_SERVICES_JSON != '' }}
-        run: echo "${{ secrets.GOOGLE_SERVICES_JSON }}" > android/app/google-services.json
+        if: ${{ env.GOOGLE_SERVICES_JSON != '' }}
+        run: echo "${{ env.GOOGLE_SERVICES_JSON }}" > android/app/google-services.json
       - name: Print API_BASE for Metro
         run: |
           echo "API_BASE=$API_BASE"


### PR DESCRIPTION
## Summary
- remove secret context references from release-apk workflow and rely solely on env vars
- ensure google-services setup uses env.GOOGLE_SERVICES_JSON

## Testing
- `npm ci`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b11122e904832eb32a254262197285