### PR TITLE
Fix Android prebuild by adding Firebase config path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,10 +4,10 @@ frontend/storybook-static/
 __pycache__/
 *.pyc
 .env*
-driver-app/android/app/google-services.json
 driver-app/**/GoogleService-Info.plist
 driver-app/node_modules/
 driver-app/android/*
 !driver-app/android/app/
 driver-app/android/app/*
+!driver-app/android/app/google-services.json
 !driver-app/android/app/google-services.json.example

--- a/driver-app/.gitignore
+++ b/driver-app/.gitignore
@@ -1,5 +1,4 @@
-android/app/google-services.json
-google-services.json
+/google-services.json
 .env
 .env.*
 

--- a/driver-app/android/app/google-services.json
+++ b/driver-app/android/app/google-services.json
@@ -1,0 +1,6 @@
+{
+  "//": "Copy this file to android/app/google-services.json for local dev.",
+  "project_info": { "project_id": "your-project-id" },
+  "client": [ { "client_info": { "mobilesdk_app_id": "1:123:android:abc" } } ]
+}
+

--- a/driver-app/app.config.ts
+++ b/driver-app/app.config.ts
@@ -4,6 +4,7 @@ export default ({ config }: { config: ExpoConfig }): ExpoConfig => {
   const android: ExpoConfig["android"] = {
     ...config.android,
     package: "com.yourco.driverAA",
+    googleServicesFile: "./android/app/google-services.json",
   };
 
   return {


### PR DESCRIPTION
## Summary
- add sample `google-services.json` for development
- configure Expo Android build to use `google-services.json`
- adjust gitignore to track the Firebase config

## Testing
- `npm ci`
- `CI=true npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_b_68b113c06480832e88b14cef4fd1d369