### PR TITLE
feat: load driver app secrets from env file in CI

### DIFF
--- a/.github/workflows/release-apk.yml
+++ b/.github/workflows/release-apk.yml
@@ -7,8 +7,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      API_BASE: ${{ secrets.API_BASE }}
-      FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}
       EXPO_NO_TELEMETRY: 1
       NODE_ENV: production
       CI: true
@@ -16,35 +14,42 @@ jobs:
       run:
         working-directory: driver-app
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
-          cache: 'npm'
+          node-version: 20
+          cache: npm
           cache-dependency-path: driver-app/package-lock.json
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: 17
+          cache: gradle
+      - name: Create .env from secret
+        run: |
+          if [ -z "${{ secrets.DRIVER_APP_ENV }}" ]; then
+            echo "DRIVER_APP_ENV secret is not set" >&2
+            exit 1
+          fi
+          printf '%s' "${{ secrets.DRIVER_APP_ENV }}" > .env
+      - name: Export .env to GITHUB_ENV
+        run: |
+          grep -v '^#' .env | grep -E '^[A-Za-z_][A-Za-z0-9_]*=' >> "$GITHUB_ENV"
+      - name: Materialize google-services.json
+        run: |
+          printf '%s' "$GOOGLE_SERVICES_JSON" | sed "s/^'//; s/'$//" > google-services.json
+          test -s google-services.json
       - name: Diagnostics
         run: |
           java -version
           keytool -list -cacerts | head -n 20
+          echo "API_BASE=$API_BASE"
       - name: Install dependencies
         run: npm ci
       - name: Prebuild Android project
         run: npx expo prebuild --platform android --non-interactive --clean
       - name: Ensure android project generated
-        run: test -d android || exit 1
-      - name: Ensure gradlew exists
-        run: test -f android/gradlew || (echo "missing gradlew" && exit 1)
-      - name: Set up google-services.json
-        if: ${{ env.GOOGLE_SERVICES_JSON != '' }}
-        run: echo "${{ env.GOOGLE_SERVICES_JSON }}" > android/app/google-services.json
-      - name: Print API_BASE for Metro
-        run: |
-          echo "API_BASE=$API_BASE"
-          node -e "console.log('Node sees API_BASE:', process.env.API_BASE || 'UNSET')"
+        run: test -d android && test -f android/gradlew
       - name: Build release APK
         run: |
           cd android
@@ -54,4 +59,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: app-release
-          path: android/app/build/outputs/apk/release/*.apk
+          path: driver-app/android/app/build/outputs/apk/release/*.apk
+

--- a/driver-app/.env.example
+++ b/driver-app/.env.example
@@ -1,2 +1,7 @@
-API_BASE=https://example.com
+# Minified JSON in a single line (no base64)
+GOOGLE_SERVICES_JSON='{"project_info":{"project_id":"your-project-id"},"client":[{"client_info":{"mobilesdk_app_id":"1:123:android:abc"}}]}'
+
+# App config
+API_BASE=https://api.example.com
+FIREBASE_PROJECT_ID=your-firebase-project
 

--- a/driver-app/.gitignore
+++ b/driver-app/.gitignore
@@ -1,4 +1,4 @@
-/google-services.json
+google-services.json
 .env
 .env.*
 

--- a/driver-app/README_DEV.md
+++ b/driver-app/README_DEV.md
@@ -1,6 +1,18 @@
 # Local Android Development
 
-1) Copy `android/app/google-services.json.example` → `android/app/google-services.json`
+**Local dev:** place `google-services.json` in the project root (`driver-app/google-services.json`) and run the prebuild; the Firebase plugin will copy it into `android/app`.
+
+**CI:** put a single GitHub Actions secret named `DRIVER_APP_ENV` containing:
+
+```
+GOOGLE_SERVICES_JSON='{"minified": "json"}'
+API_BASE=https://your.api
+FIREBASE_PROJECT_ID=your-project-id
+```
+
+Use `jq -c . google-services.json` to minify; no base64 needed.
+
+1) Ensure `google-services.json` exists in the project root
 2) Set `API_BASE` via `.env` or CLI
 3) `npm ci`
 4) `npx expo prebuild --platform android`

--- a/driver-app/app.config.ts
+++ b/driver-app/app.config.ts
@@ -4,7 +4,7 @@ export default ({ config }: { config: ExpoConfig }): ExpoConfig => {
   const android: ExpoConfig["android"] = {
     ...config.android,
     package: "com.yourco.driverAA",
-    googleServicesFile: "./android/app/google-services.json",
+    googleServicesFile: "./google-services.json",
   };
 
   return {

--- a/driver-app/docs/firebase-dev.md
+++ b/driver-app/docs/firebase-dev.md
@@ -1,9 +1,18 @@
 # Firebase Local Development
 
 1. Create a Firebase project and download `google-services.json`.
-2. Copy it into `android/app/google-services.json`.
+2. Place it at `driver-app/google-services.json`; Expo's `googleServicesFile` points to `./google-services.json`, and the plugin will copy it into `android/app`.
 3. (Optional) For iOS, place `GoogleService-Info.plist` in the iOS project.
-4. Install dependencies and run the app:
+4. For CI, store environment variables in a single GitHub secret `DRIVER_APP_ENV` containing:
+
+   ```
+   GOOGLE_SERVICES_JSON='{"minified": "json"}'
+   API_BASE=https://your.api
+   FIREBASE_PROJECT_ID=your-project-id
+   ```
+
+   Minify the JSON with `jq -c . google-services.json`; no base64 needed.
+5. Install dependencies and run the app:
 
 ```
 npm install


### PR DESCRIPTION
## Summary
- reference google-services.json from project root
- load CI config from DRIVER_APP_ENV and materialize google-services.json before prebuild
- document new env/secret workflow and provide sample `.env` template

## Testing
- `npm ci`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b11c544b18832eb7b24ae4c7dc333b