### PR TITLE
chore(driver-app): build with google-services.json from .env

### DIFF
--- a/.github/workflows/driver-app-ci.yml
+++ b/.github/workflows/driver-app-ci.yml
@@ -13,9 +13,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    env:
-      JAVA_TOOL_OPTIONS: -Djavax.net.ssl.trustStore=$JAVA_HOME/lib/security/cacerts -Djavax.net.ssl.trustStoreType=JKS
-      GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx2g"
     defaults:
       run:
         working-directory: driver-app
@@ -24,13 +21,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: 'npm'
+          cache: npm
           cache-dependency-path: driver-app/package-lock.json
-      - uses: actions/setup-java@v4
-        with:
-          distribution: 'temurin'
-          java-version: '17'
-      - run: java -version && keytool -list -cacerts | head -n 5
       - run: npm ci
       - run: npm run typecheck
       - run: npm test

--- a/.github/workflows/release-apk.yml
+++ b/.github/workflows/release-apk.yml
@@ -20,11 +20,6 @@ jobs:
           node-version: 20
           cache: npm
           cache-dependency-path: driver-app/package-lock.json
-      - uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: 17
-          cache: gradle
       - name: Create .env from secret
         run: |
           if [ -z "${{ secrets.DRIVER_APP_ENV }}" ]; then
@@ -39,25 +34,24 @@ jobs:
         run: |
           printf '%s' "$GOOGLE_SERVICES_JSON" | sed "s/^'//; s/'$//" > google-services.json
           test -s google-services.json
-      - name: Diagnostics
-        run: |
-          java -version
-          keytool -list -cacerts | head -n 20
-          echo "API_BASE=$API_BASE"
       - name: Install dependencies
         run: npm ci
       - name: Prebuild Android project
         run: npx expo prebuild --platform android --non-interactive --clean
       - name: Ensure android project generated
         run: test -d android && test -f android/gradlew
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+          cache: gradle
+          cache-dependency-path: driver-app/android/gradle/wrapper/gradle-wrapper.properties
       - name: Build release APK
         run: |
           cd android
           chmod +x gradlew
-          ./gradlew assembleRelease
-      - name: Upload APK artifact
-        uses: actions/upload-artifact@v4
+          ./gradlew --no-daemon assembleRelease
+      - uses: actions/upload-artifact@v4
         with:
           name: app-release
           path: driver-app/android/app/build/outputs/apk/release/*.apk
-

--- a/driver-app/.env.example
+++ b/driver-app/.env.example
@@ -1,7 +1,6 @@
 # Minified JSON in a single line (no base64)
 GOOGLE_SERVICES_JSON='{"project_info":{"project_id":"your-project-id"},"client":[{"client_info":{"mobilesdk_app_id":"1:123:android:abc"}}]}'
 
-# App config
+# App config (examples)
 API_BASE=https://api.example.com
 FIREBASE_PROJECT_ID=your-firebase-project
-

--- a/driver-app/.gitignore
+++ b/driver-app/.gitignore
@@ -1,4 +1,3 @@
 google-services.json
 .env
 .env.*
-

--- a/driver-app/README_DEV.md
+++ b/driver-app/README_DEV.md
@@ -1,20 +1,21 @@
 # Local Android Development
 
-**Local dev:** place `google-services.json` in the project root (`driver-app/google-services.json`) and run the prebuild; the Firebase plugin will copy it into `android/app`.
+## Quick start
 
-**CI:** put a single GitHub Actions secret named `DRIVER_APP_ENV` containing:
+Local dev: place your real `driver-app/google-services.json` and run `npx expo prebuild`. The plugin will copy it into `android/app/`.
+
+CI: create one GitHub Secret `DRIVER_APP_ENV` with lines like:
 
 ```
-GOOGLE_SERVICES_JSON='{"minified": "json"}'
-API_BASE=https://your.api
+GOOGLE_SERVICES_JSON='{"minified":"json","…":"…"}'
+API_BASE=https://api.example.com
 FIREBASE_PROJECT_ID=your-project-id
 ```
 
-Use `jq -c . google-services.json` to minify; no base64 needed.
+Use `jq -c . google-services.json` to produce the single-line JSON for `GOOGLE_SERVICES_JSON`. No base64 required.
 
 1) Ensure `google-services.json` exists in the project root
 2) Set `API_BASE` via `.env` or CLI
 3) `npm ci`
 4) `npx expo prebuild --platform android`
 5) `cd android && ./gradlew assembleDebug` or `npm run android`
-

--- a/driver-app/docs/firebase-dev.md
+++ b/driver-app/docs/firebase-dev.md
@@ -3,15 +3,15 @@
 1. Create a Firebase project and download `google-services.json`.
 2. Place it at `driver-app/google-services.json`; Expo's `googleServicesFile` points to `./google-services.json`, and the plugin will copy it into `android/app`.
 3. (Optional) For iOS, place `GoogleService-Info.plist` in the iOS project.
-4. For CI, store environment variables in a single GitHub secret `DRIVER_APP_ENV` containing:
+4. For CI, create one GitHub Secret `DRIVER_APP_ENV` with lines like:
 
-   ```
-   GOOGLE_SERVICES_JSON='{"minified": "json"}'
-   API_BASE=https://your.api
-   FIREBASE_PROJECT_ID=your-project-id
-   ```
+```
+GOOGLE_SERVICES_JSON='{"minified":"json","…":"…"}'
+API_BASE=https://api.example.com
+FIREBASE_PROJECT_ID=your-project-id
+```
 
-   Minify the JSON with `jq -c . google-services.json`; no base64 needed.
+Use `jq -c . google-services.json` to produce the single-line JSON for `GOOGLE_SERVICES_JSON`. No base64 required.
 5. Install dependencies and run the app:
 
 ```
@@ -20,4 +20,3 @@ npm run android
 ```
 
 The Android build expects the file to exist; without it, Expo may fail to run.
-


### PR DESCRIPTION
## Summary
- load Android google-services.json from GOOGLE_SERVICES_JSON in a single DRIVER_APP_ENV secret
- run Expo prebuild before initializing Java and Gradle caching
- simplify driver-app CI to Node 20 only and document env usage

## Testing
- `npm ci`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b11e288b10832e9462a763afd125e9