### PR TITLE
ci: build driver app release apk

### DIFF
--- a/.github/workflows/driver-app-ci.yml
+++ b/.github/workflows/driver-app-ci.yml
@@ -21,6 +21,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
+          # Node 20 LTS with npm cache
           node-version: 20
           cache: npm
           cache-dependency-path: driver-app/package-lock.json

--- a/.github/workflows/release-apk.yml
+++ b/.github/workflows/release-apk.yml
@@ -25,12 +25,11 @@ jobs:
           node-version: 20
           cache: npm
           cache-dependency-path: driver-app/package-lock.json
-      - name: Create google-services.json from secret
+      - name: Create google-services.json from secret (RAW JSON, not base64)
         run: |
           if [ -z "${GOOGLE_SERVICES_JSON}" ]; then
             echo "ERROR: Missing GOOGLE_SERVICES_JSON secret"; exit 1
           fi
-          # Strip one layer of surrounding quotes if a user pasted it quoted
           VAL="${GOOGLE_SERVICES_JSON}"
           case "$VAL" in
             \"*) VAL="${VAL%\"}"; VAL="${VAL#\"}";;
@@ -38,11 +37,6 @@ jobs:
           esac
           printf "%s" "$VAL" > google-services.json
           test -s google-services.json || { echo "ERROR: google-services.json empty"; exit 1; }
-
-      # - name: (Optional) Write service-account.json for Firebase tools
-      #   run: |
-      #     printf "%s" "$FIREBASE_SERVICE_ACCOUNT_JSON" > service-account.json
-      #     test -s service-account.json
 
       - name: Install dependencies
         run: npm ci

--- a/driver-app/.gitignore
+++ b/driver-app/.gitignore
@@ -1,2 +1,3 @@
+# Ignore local secrets
 google-services.json
 .env

--- a/driver-app/android/app/google-services.json.example
+++ b/driver-app/android/app/google-services.json.example
@@ -1,5 +1,5 @@
 {
-  "//": "Copy this file to android/app/google-services.json for local dev.",
+  "//": "Place real google-services.json at driver-app/google-services.json; expo prebuild copies it into android/app/.",
   "project_info": { "project_id": "your-project-id" },
   "client": [ { "client_info": { "mobilesdk_app_id": "1:123:android:abc" } } ]
 }

--- a/driver-app/app/entry.tsx
+++ b/driver-app/app/entry.tsx
@@ -1,0 +1,5 @@
+// Ensure background FCM handler is registered for Android headless tasks
+import "../src/infrastructure/firebase/background-handler";
+
+export { default } from "expo-router/entry";
+

--- a/driver-app/app/expo-router.d.ts
+++ b/driver-app/app/expo-router.d.ts
@@ -1,0 +1,2 @@
+declare module "expo-router/entry";
+


### PR DESCRIPTION
## Summary
- create google-services.json from secret before expo prebuild and run setup-java afterward
- simplify driver-app CI to Node+npm only
- register Firebase background handler via Expo Router entry and document google-services.json

## Testing
- `npm ci`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b1256f4488832e8d4a65532daecb08