### PR TITLE
chore: remove deprecated babel plugin

### DIFF
--- a/driver-app/babel.config.js
+++ b/driver-app/babel.config.js
@@ -3,7 +3,6 @@ module.exports = function (api) {
   return {
     presets: ['babel-preset-expo'],
     plugins: [
-      'expo-router/babel',
       // NOTE: This plugin must be last
       'react-native-reanimated/plugin',
     ],


### PR DESCRIPTION
## Summary
- remove deprecated expo-router plugin from Babel config

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_b_68b14e42100c832eaf40718c77b02d8f