### PR TITLE
chore: update Expo export for APK workflow

### DIFF
--- a/.github/workflows/release-apk.yml
+++ b/.github/workflows/release-apk.yml
@@ -48,10 +48,11 @@ jobs:
       - name: Verify JS bundle (Expo) and capture logs
         env:
           EXPO_DEBUG: 1
+          CI: 1
         run: |
           set -o pipefail
-          # Try Expo export first (SDK 50+): use --no-dev instead of '--dev false'
-          (npx expo export --platform android --no-dev --non-interactive \
+          # Try Expo export first (SDK 50+). Defaults to production; no --dev/--no-dev flag.
+          (npx expo export --platform android \
             --output-dir .expo/export \
             --dump-sourcemap --dump-assetmap --clear) 2>&1 | tee -a expo-bundle.log
           STATUS=${PIPESTATUS[0]}


### PR DESCRIPTION
## Summary
- update Expo export command and enable CI mode for bundling

## Testing
- `cd driver-app && npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b15570ce44832e8aa549473563ad1a