### PR TITLE
feat: include js polyfills and update release workflow

### DIFF
--- a/.github/workflows/release-apk.yml
+++ b/.github/workflows/release-apk.yml
@@ -42,15 +42,10 @@ jobs:
           yarn -v || echo "Yarn not installed"
           npm -v
           if [ -n "$API_BASE" ]; then echo "API_BASE is set"; else echo "API_BASE is not set"; fi
-      - name: Install dependencies (include dev deps)
+      - name: Install dependencies (allow new deps)
         env:
-          # Unset NODE_ENV so npm installs devDependencies (Babel plugins, etc.)
           NODE_ENV: ""
-        run: npm ci
-      - name: Verify babel-plugin-module-resolver present
-        run: |
-          npm ls --depth=0 babel-plugin-module-resolver || true
-          node -e "console.log('module-resolver path:', require.resolve('babel-plugin-module-resolver'))"
+        run: npm install --no-audit --no-fund
       - name: Verify JS bundle (Expo) and capture logs
         env:
           EXPO_DEBUG: 1

--- a/driver-app/package-lock.json
+++ b/driver-app/package-lock.json
@@ -13,7 +13,9 @@
         "@react-native-firebase/app": "^19.0.0",
         "@react-native-firebase/auth": "^19.0.0",
         "@react-native-firebase/messaging": "^19.0.0",
+        "@react-native/js-polyfills": "^0.76.0",
         "@tanstack/react-query": "^5.0.0",
+        "babel-plugin-module-resolver": "^5.0.0",
         "expo": "^52.0.0",
         "expo-router": "^3.0.0",
         "react": "18.2.0",
@@ -25,7 +27,6 @@
         "@types/jest": "^29.0.0",
         "@types/react": "^18.2.0",
         "@types/react-native": "^0.72.0",
-        "babel-plugin-module-resolver": "^5.0.2",
         "jest": "^29.0.0",
         "ts-jest": "^29.0.0",
         "typescript": "^5.0.0"
@@ -4723,6 +4724,15 @@
         "node": ">=18"
       }
     },
+    "node_modules/@react-native/js-polyfills": {
+      "version": "0.76.9",
+      "resolved": "https://registry.npmjs.org/@react-native/js-polyfills/-/js-polyfills-0.76.9.tgz",
+      "integrity": "sha512-s6z6m8cK4SMjIX1hm8LT187aQ6//ujLrjzDBogqDCYXRbfjbAYovw5as/v2a2rhUIyJbS3UjokZm3W0H+Oh/RQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@react-native/normalize-colors": {
       "version": "0.74.85",
       "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.74.85.tgz",
@@ -5611,7 +5621,6 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/babel-plugin-module-resolver/-/babel-plugin-module-resolver-5.0.2.tgz",
       "integrity": "sha512-9KtaCazHee2xc0ibfqsDeamwDps6FZNo5S0Q81dUqEuFzVwPhcT4J5jOqIVvgCA3Q/wO9hKYxN/Ds3tIsp5ygg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "find-babel-config": "^2.1.1",
@@ -5625,7 +5634,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
       "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -5635,7 +5643,6 @@
       "version": "9.3.5",
       "resolved": "https://registry.npmjs.org/glob/-/glob-9.3.5.tgz",
       "integrity": "sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -5654,7 +5661,6 @@
       "version": "8.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.4.tgz",
       "integrity": "sha512-W0Wvr9HyFXZRGIDgCicunpQ299OKXs9RgZfaukz4qAW/pJhcpUfupc9c+OObPOFueNy8VSrZgEmDtk6Kh4WzDA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -5670,7 +5676,6 @@
       "version": "4.2.8",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
       "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=8"
@@ -8183,7 +8188,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/find-babel-config/-/find-babel-config-2.1.2.tgz",
       "integrity": "sha512-ZfZp1rQyp4gyuxqt1ZqjFGVeVBvmpURMqdIWXbPRfB97Bf6BzdK/xSIbylEINzQ0kB5tlDQfn9HkNXXWsqTqLg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "json5": "^2.2.3"
@@ -11945,7 +11949,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-3.1.0.tgz",
       "integrity": "sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "find-up": "^3.0.0"
@@ -11958,7 +11961,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
       "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "locate-path": "^3.0.0"
@@ -11971,7 +11973,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
       "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-locate": "^3.0.0",
@@ -11985,7 +11986,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
       "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-try": "^2.0.0"
@@ -12001,7 +12001,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
       "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-limit": "^2.0.0"
@@ -12014,7 +12013,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
       "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -12765,7 +12763,6 @@
       "version": "4.1.8",
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.8.tgz",
       "integrity": "sha512-ab9EmR80F/zQTMNeneUr4cv+jSwPJgIlvEmVwLerwrWVbpLlBuls9XHzIeTFy4cegU2NHBp3va0LKOzU5qFEYQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/resolve": {

--- a/driver-app/package.json
+++ b/driver-app/package.json
@@ -15,7 +15,9 @@
     "@react-native-firebase/app": "^19.0.0",
     "@react-native-firebase/auth": "^19.0.0",
     "@react-native-firebase/messaging": "^19.0.0",
+    "@react-native/js-polyfills": "^0.76.0",
     "@tanstack/react-query": "^5.0.0",
+    "babel-plugin-module-resolver": "^5.0.0",
     "expo": "^52.0.0",
     "expo-router": "^3.0.0",
     "react": "18.2.0",
@@ -27,7 +29,6 @@
     "@types/jest": "^29.0.0",
     "@types/react": "^18.2.0",
     "@types/react-native": "^0.72.0",
-    "babel-plugin-module-resolver": "^5.0.0",
     "jest": "^29.0.0",
     "ts-jest": "^29.0.0",
     "typescript": "^5.0.0"


### PR DESCRIPTION
## Summary
- add `@react-native/js-polyfills` and move `babel-plugin-module-resolver` into runtime dependencies
- simplify release workflow by using `npm install` to allow new deps

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_b_68b163248c84832eaeef5ecdf90090c6