### PR TITLE
chore: run prebuild before java setup

### DIFF
--- a/.github/workflows/driver-app-android.yml
+++ b/.github/workflows/driver-app-android.yml
@@ -41,13 +41,6 @@ jobs:
           cache: npm
           cache-dependency-path: driver-app/package-lock.json
 
-      - name: Setup Java 17 (Gradle)
-        uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: 17
-          cache: gradle
-
       - name: Install dependencies (include devDependencies)
         env:
           NODE_ENV: ""
@@ -82,6 +75,13 @@ jobs:
             fi
           } >> android/gradle.properties
           tail -n +1 android/gradle.properties
+
+      - name: Setup Java 17 (Gradle)
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+          cache: gradle
 
       - name: Build release APK
         run: |


### PR DESCRIPTION
## Summary
- run Expo prebuild prior to setting up Java in the Android release workflow to ensure the native project exists before Gradle setup

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_b_68b175c5fdd0832ea9b343c513ed5445