### PR TITLE
fix(android): remove invalid Notifee config plugin, remove --non-interactive, keep FCM/Notifee working

### DIFF
--- a/.github/workflows/driver-app-android.yml
+++ b/.github/workflows/driver-app-android.yml
@@ -61,7 +61,7 @@ jobs:
           test -s android/app/google-services.json || { echo "ERROR: google-services.json empty"; exit 1; }
 
       - name: Prebuild native project
-        run: npx expo prebuild --platform android --non-interactive --clean
+        run: npx expo prebuild --platform android --clean
 
       - name: Ensure android project exists
         run: test -d android && test -f android/gradlew

--- a/driver-app/app.config.ts
+++ b/driver-app/app.config.ts
@@ -17,6 +17,5 @@ export default ({ config }: any) => ({
     ['expo-build-properties', { android: { compileSdkVersion: 35, targetSdkVersion: 34, kotlinVersion: '1.9.25' } }],
     '@react-native-firebase/app',
     '@react-native-firebase/messaging',
-    '@notifee/react-native',
   ],
 });

--- a/driver-app/package.json
+++ b/driver-app/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "expo start",
     "android": "expo run:android",
-    "prebuild:android": "npx expo prebuild --platform android --non-interactive --clean",
+    "prebuild:android": "npx expo prebuild --platform android --clean",
     "android:bundle": "expo export:embed --platform android --dev false --reset-cache",
     "android:release": "cd android && ./gradlew assembleRelease",
     "test": "jest --passWithNoTests",


### PR DESCRIPTION
## Summary
- remove Notifee from Expo config plugins
- drop unsupported `--non-interactive` flag from prebuild scripts and workflow

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_b_68b1b3274b5c832e887de50067beeed8