### PR TITLE
fix: add driver package to Google services example

### DIFF
--- a/driver-app/android/app/google-services.json.example
+++ b/driver-app/android/app/google-services.json.example
@@ -1,6 +1,13 @@
 {
   "//": "Place real google-services.json at driver-app/google-services.json; expo prebuild copies it into android/app/.",
   "project_info": { "project_id": "your-project-id" },
-  "client": [ { "client_info": { "mobilesdk_app_id": "1:123:android:abc" } } ]
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:123:android:abc",
+        "android_client_info": { "package_name": "com.orderops.driver" }
+      }
+    }
+  ]
 }
 


### PR DESCRIPTION
## Summary
- ensure sample google-services file includes driver package name

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b1be04127c832ea1870fcba21d4a52