### PR TITLE
chore: refine Android workflow Java setup

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -35,9 +35,8 @@ jobs:
       - name: Setup Java 17
         uses: actions/setup-java@v4
         with:
-          distribution: 'temurin'
+          distribution: temurin
           java-version: '17'
-          cache: 'gradle'
 
       - name: Install npm deps
         run: npm ci
@@ -46,6 +45,18 @@ jobs:
         run: |
           npm run clean:android || true
           npm run prebuild:android
+
+      - name: Setup Java 17 (enable Gradle cache post-prebuild)
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: gradle
+          cache-dependency-path: |
+            driver-app/android/**/gradle-wrapper.properties
+            driver-app/android/**/*.gradle*
+            driver-app/android/gradle/*.versions.toml
+            driver-app/android/**/versions.properties
 
       - name: Patch Android Gradle properties (1st pass)
         run: node scripts/ci/patch-android-gradle.js || true


### PR DESCRIPTION
## Summary
- simplify initial Java setup by removing Gradle cache
- add second Java setup after prebuild with Gradle cache

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b1d8a7725c832e99f34a100257c48c