### PR TITLE
Enable AndroidX for driver app

### DIFF
--- a/driver-app/gradle.properties
+++ b/driver-app/gradle.properties
@@ -1,0 +1,4 @@
+# Enable AndroidX
+android.useAndroidX=true
+# Automatically convert third-party libraries to use AndroidX
+android.enableJetifier=true


### PR DESCRIPTION
## Summary
- enable AndroidX and Jetifier via gradle properties for driver app

## Testing
- `gradle -p driver-app tasks`
- `gradle -p driver-app assembleRelease --dry-run` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b23c6a9db8832e8a153fb9400b12d2